### PR TITLE
Issue #19: Fixed connection leak issue in mapred.TableOutputFormat class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+#IDE
+.idea/
+*.iml
+
+# Maven
+target/
+


### PR DESCRIPTION
Highlights:
1. Used TableOutputFormat from mapreduce package instead of mapred
2. mapreduce.TableOutputFormat is the newer implementation which has the HBASE-16017 fixed.
3. Added gitignore 
4. Used saveAsNewAPIHadoopDataset 

Notes:
All tests passing.