### PR TITLE
Minor change, improves performance of OR drastically.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/ScanRange.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/ScanRange.scala
@@ -19,11 +19,12 @@ package org.apache.spark.sql.execution.datasources.hbase
 
 import scala.collection.mutable.ArrayBuffer
 import scala.math.Ordering
-
 import org.apache.hadoop.hbase.util.Bytes
 import org.apache.spark.Logging
 import org.apache.spark.sql.execution.datasources.hbase
 import org.apache.spark.unsafe.types.UTF8String
+
+import scala.annotation.tailrec
 
 case class Bound[T](point: T, inc: Boolean)(implicit ordering: Ordering[T]) {
   override def toString = {
@@ -250,11 +251,15 @@ object ScanRange {
     }
   }
 
-  def or[T](
+  @tailrec def or[T](
       left:  Array[ScanRange[T]],
       right:  Array[ScanRange[T]])(implicit ordering: Ordering[T]): Array[ScanRange[T]] = {
-    left.foldLeft(right){ case (x, y) =>
-      ScanRange.or(y, x)
+    if(left.size <= right.size) {
+      left.foldLeft(right){ case (x, y) =>
+        ScanRange.or(y, x)
+      }
+    } else {
+      or(right, left)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/ScanRange.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/ScanRange.scala
@@ -254,7 +254,7 @@ object ScanRange {
   @tailrec def or[T](
       left:  Array[ScanRange[T]],
       right:  Array[ScanRange[T]])(implicit ordering: Ordering[T]): Array[ScanRange[T]] = {
-    if(left.size <= right.size) {
+    if(left.length <= right.length) {
       left.foldLeft(right){ case (x, y) =>
         ScanRange.or(y, x)
       }


### PR DESCRIPTION
On local tests, using this to "OR" 2000 equals checks took around 600ms compared to 170s taken by the original version.