### PR TITLE
Make avro definition in catalog backwards compatible

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Phoenix.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Phoenix.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.datasources.hbase.types
 
-
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable
 import org.apache.phoenix.query.QueryConstants
 import org.apache.phoenix.schema._

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/SHCDataType.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/SHCDataType.scala
@@ -48,7 +48,7 @@ trait SHCDataType extends Serializable {
 
 /**
  * Currently, SHC supports three data types which can be used as serdes: Avro, Phoenix, PrimitiveType.
- * Adding New SHC data type should needs to implement the trait 'SHCDataType'.
+ * Adding New SHC data type needs to implement the trait 'SHCDataType'.
  */
 object SHCDataTypeFactory {
 
@@ -75,7 +75,7 @@ object SHCDataTypeFactory {
   }
 
   // Currently, the function below is only used for creating the table coder.
-  // One catalog/ Hbase table can only use one table coder, so the function is
+  // One catalog/HBase table can only use one table coder, so the function is
   // only called once in 'HBaseTableCatalog' class.
   def create(coder: String): SHCDataType = {
     if (coder == null || coder.isEmpty) {

--- a/core/src/test/scala/org/apache/spark/sql/AvroKeySourceSuite.java
+++ b/core/src/test/scala/org/apache/spark/sql/AvroKeySourceSuite.java
@@ -138,8 +138,8 @@ public class AvroKeySourceSuite {
   private static Map<String, String> getHBaseSourceOptions() {
     String hbaseCatalog = "{\"table\": {\"namespace\": \"default\", \"name\": \"TEST_TABLE\", \"tableCoder\":\"PrimitiveType\"}," +
         "\"rowkey\": \"key\", \"columns\": {"
-        + "\"key\": {\"cf\": \"rowkey\", \"col\": \"key\", \"type\": \"keySchema\", \"coder\": \"Avro\"},"
-        + "\"value\": {\"cf\": \"" + COLUMN_FAMILY + "\", \"col\": \"" + COLUMN_QUALIFIER + "\", \"type\": \"avroSchema\", \"coder\": \"Avro\"}"
+        + "\"key\": {\"cf\": \"rowkey\", \"col\": \"key\", \"avro\": \"keySchema\"},"
+        + "\"value\": {\"cf\": \"" + COLUMN_FAMILY + "\", \"col\": \"" + COLUMN_QUALIFIER + "\", \"avro\": \"avroSchema\"}"
         + "}}";
     Map<String, String> hbaseOptions = new HashMap<>();
     hbaseOptions.put(HBaseTableCatalog.tableCatalog(), hbaseCatalog);

--- a/core/src/test/scala/org/apache/spark/sql/AvroSourceKeySuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/AvroSourceKeySuite.scala
@@ -64,8 +64,8 @@ class AvroSourceKeySuite extends SHC with Logging{
             |"table":{"namespace":"default", "name":"avrotable", "tableCoder":"PrimitiveType"},
             |"rowkey":"key",
             |"columns":{
-              |"col0":{"cf":"rowkey", "col":"key", "type":"avroSchema", "coder":"Avro"},
-              |"col1":{"cf":"cf1", "col":"col1", "type":"avroSchema", "coder":"Avro"}
+              |"col0":{"cf":"rowkey", "col":"key", "avro":"avroSchema"},
+              |"col1":{"cf":"cf1", "col":"col1", "avro":"avroSchema"}
             |}
           |}""".stripMargin
 
@@ -73,8 +73,8 @@ class AvroSourceKeySuite extends SHC with Logging{
             |"table":{"namespace":"default", "name":"avrotableInsert", "tableCoder":"PrimitiveType"},
             |"rowkey":"key",
             |"columns":{
-              |"col0":{"cf":"rowkey", "col":"key", "type":"avroSchema", "coder":"Avro"},
-              |"col1":{"cf":"cf1", "col":"col1", "type":"avroSchema", "coder":"Avro"}
+              |"col0":{"cf":"rowkey", "col":"key", "avro":"avroSchema"},
+              |"col1":{"cf":"cf1", "col":"col1", "avro":"avroSchema"}
             |}
           |}""".stripMargin
 

--- a/core/src/test/scala/org/apache/spark/sql/AvroSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/AvroSourceSuite.scala
@@ -12,7 +12,7 @@ case class AvroHBaseRecord(col0: String,
 object AvroHBaseRecord {
   val schemaString =
     s"""{"namespace": "example.avro",
-         |   "type": "record",      "name": "User",
+         |   "type": "record", "name": "User",
          |    "fields": [
          |        {"name": "name", "type": "string"},
          |        {"name": "favorite_number",  "type": ["int", "null"]},
@@ -61,7 +61,7 @@ class AvroSourceSuite extends SHC with Logging{
             |"rowkey":"key",
             |"columns":{
               |"col0":{"cf":"rowkey", "col":"key", "type":"string"},
-              |"col1":{"cf":"cf1", "col":"col1", "type":"avroSchema", "coder":"Avro"}
+              |"col1":{"cf":"cf1", "col":"col1", "avro":"avroSchema"}
             |}
           |}""".stripMargin
 
@@ -70,7 +70,7 @@ class AvroSourceSuite extends SHC with Logging{
             |"rowkey":"key",
             |"columns":{
               |"col0":{"cf":"rowkey", "col":"key", "type":"string"},
-              |"col1":{"cf":"cf1", "col":"col1", "type":"avroSchema", "coder":"Avro"}
+              |"col1":{"cf":"cf1", "col":"col1", "avro":"avroSchema"}
             |}
           |}""".stripMargin
 

--- a/core/src/test/scala/org/apache/spark/sql/DataTypeConverter.scala
+++ b/core/src/test/scala/org/apache/spark/sql/DataTypeConverter.scala
@@ -28,10 +28,10 @@ class DataTypeConverter extends SHC with Logging{
     val complex = s"""MAP<int, struct<varchar:string>>"""
     val schema =
       s"""{"namespace": "example.avro",
-         |   "type": "record",      "name": "User",
-         |    "fields": [      {"name": "name", "type": "string"},
+         |   "type": "record", "name": "User",
+         |    "fields": [ {"name": "name", "type": "string"},
          |      {"name": "favorite_number",  "type": ["int", "null"]},
-         |        {"name": "favorite_color", "type": ["string", "null"]}      ]    }""".stripMargin
+         |        {"name": "favorite_color", "type": ["string", "null"]} ]}""".stripMargin
 
     val catalog = s"""{
             |"table":{"namespace":"default", "name":"htable", "tableCoder":"PrimitiveType"},

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/AvroRecord.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/AvroRecord.scala
@@ -35,14 +35,14 @@ object AvroRecord {
       val p = new Schema.Parser
       p.parse(schemaString)
     }
-    val user1 = new GenericData.Record(avroSchema);
-    user1.put("name", "Alyssa");
-    user1.put("favorite_number", 256);
+    val user1 = new GenericData.Record(avroSchema)
+    user1.put("name", "Alyssa")
+    user1.put("favorite_number", 256)
 
-    val user2 = new GenericData.Record(avroSchema);
-    user2.put("name", "Ben");
-    user2.put("favorite_number", 7);
-    user2.put("favorite_color", "red");
+    val user2 = new GenericData.Record(avroSchema)
+    user2.put("name", "Ben")
+    user2.put("favorite_number", 7)
+    user2.put("favorite_color", "red")
 
     val sqlUser1 = SchemaConverters.createConverterToSQL(avroSchema)(user1)
     println(sqlUser1)

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/AvroSource.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/AvroSource.scala
@@ -77,7 +77,7 @@ object AvroSource {
                         |"rowkey":"key",
                         |"columns":{
                         |"col0":{"cf":"rowkey", "col":"key", "type":"string"},
-                        |"col1":{"cf":"cf1", "col":"col1", "type":"avroSchema", "coder":"Avro"}
+                        |"col1":{"cf":"cf1", "col":"col1", "avro":"avroSchema"}
                         |}
                         |}""".stripMargin
 
@@ -86,7 +86,7 @@ object AvroSource {
                               |"rowkey":"key",
                               |"columns":{
                               |"col0":{"cf":"rowkey", "col":"key", "type":"string"},
-                              |"col1":{"cf":"cf1", "col":"col1", "type":"avroSchema", "coder":"Avro"}
+                              |"col1":{"cf":"cf1", "col":"col1", "avro":"avroSchema"}
                               |}
                               |}""".stripMargin
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Make avro definition in catalog backwards compatible: use `"avro": schema` instead

## How was this patch tested?
Pass current unit tests.
