### PR TITLE
Make 'buildSchema' happen once for task instead of per row

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Phoenix.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Phoenix.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.execution.datasources.hbase._
 import org.apache.spark.sql.types._
 
 class Phoenix(f:Option[Field] = None) extends SHCDataType {
+  private var schema: RowKeySchema = null
 
   def fromBytes(src: HBaseType): Any = {
     if (f.isDefined) {
@@ -60,15 +61,7 @@ class Phoenix(f:Option[Field] = None) extends SHCDataType {
   override def isCompositeKeySupported(): Boolean = true
 
   override def decodeCompositeRowKey(row: Array[Byte], keyFields: Seq[Field]): Map[Field, Any] = {
-    def buildSchema(): RowKeySchema = {
-      val builder: RowKeySchemaBuilder = new RowKeySchemaBuilder(keyFields.length)
-      keyFields.foreach{ x =>
-        builder.addField(buildPDatum(x.dt), false, SortOrder.getDefault)
-      }
-      builder.build
-    }
-    val schema: RowKeySchema = buildSchema()
-
+    if (schema == null) schema = buildSchema(keyFields)
     val ptr: ImmutableBytesWritable = new ImmutableBytesWritable
     val maxOffest = schema.iterator(row, 0, row.length, ptr)
     var ret = Map.empty[Field, Any]
@@ -90,6 +83,14 @@ class Phoenix(f:Option[Field] = None) extends SHCDataType {
         ret ++= QueryConstants.SEPARATOR_BYTE_ARRAY
       ret
     }
+  }
+
+  private def buildSchema(keyFields: Seq[Field]): RowKeySchema = {
+    val builder: RowKeySchemaBuilder = new RowKeySchemaBuilder(keyFields.length)
+    keyFields.foreach{ x =>
+      builder.addField(buildPDatum(x.dt), false, SortOrder.getDefault)
+    }
+    builder.build
   }
 
   private def mapToPhoenixTypeInstance(input: DataType): PDataType[_] = {

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/AvroSource.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/AvroSource.scala
@@ -46,7 +46,7 @@ object AvroHBaseRecord {
 
   def apply(i: Int): AvroHBaseRecord = {
 
-    val user = new GenericData.Record(avroSchema);
+    val user = new GenericData.Record(avroSchema)
     user.put("name", s"name${"%03d".format(i)}")
     user.put("favorite_number", i)
     user.put("favorite_color", s"color${"%03d".format(i)}")


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is to fix review comments in PR#84.
In the `decodeCompositeRowKey` function, make 'buildSchema' happen once for task instead of per row.

## How was this patch tested?
Pass current unit tests.
