### PR TITLE
Fix bug about 'tinyint' in Phoenix coder

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -104,12 +104,7 @@ private[hbase] class HBaseTableScanRDD(
         (x, null)
       } else {
         val v = CellUtil.cloneValue(kv)
-        (x, x.dt match {
-          // Here, to avoid arraycopy, return v directly instead of calling bytesToColumn()
-          // to covert hbase field to Scala type
-          case BinaryType => v
-          case _ => SHCDataTypeFactory.create(x).fromBytes(v)
-        })
+        (x, SHCDataTypeFactory.create(x).fromBytes(v))
       }
     }.toMap
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Phoenix.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Phoenix.scala
@@ -31,11 +31,7 @@ class Phoenix(f:Option[Field] = None) extends SHCDataType {
 
   def fromBytes(src: HBaseType): Any = {
     if (f.isDefined) {
-      f.get.dt match {
-        case ByteType => src(0)
-        case BinaryType => src
-        case _ => mapToPhoenixTypeInstance(f.get.dt).toObject(src)
-      }
+      mapToPhoenixTypeInstance(f.get.dt).toObject(src)
     } else {
       throw new UnsupportedOperationException(
         "Phoenix coder: without field metadata, 'fromBytes' conversion can not be supported")
@@ -46,7 +42,7 @@ class Phoenix(f:Option[Field] = None) extends SHCDataType {
     input match {
       case data: Boolean => PBoolean.INSTANCE.toBytes(data)
       case data: Byte => PTinyint.INSTANCE.toBytes(data)
-      case data: Array[Byte] => data
+      case data: Array[Byte] => PVarbinary.INSTANCE.toBytes(data)
       case data: Double => PDouble.INSTANCE.toBytes(data)
       case data: Float => PFloat.INSTANCE.toBytes(data)
       case data: Int => PInteger.INSTANCE.toBytes(data)
@@ -104,7 +100,7 @@ class Phoenix(f:Option[Field] = None) extends SHCDataType {
       case LongType => PLong.INSTANCE
       case ShortType => PSmallint.INSTANCE
       case StringType => PVarchar.INSTANCE
-      case BinaryType => PBinary.INSTANCE
+      case BinaryType => PVarbinary.INSTANCE
       case _ => throw new UnsupportedOperationException(s"unsupported data type $input")
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/PhoenixSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/PhoenixSuite.scala
@@ -98,6 +98,12 @@ class PhoenixSuite extends SHC with Logging {
       .save()
   }
 
+  test("full query") {
+    val df = withCatalog(catalog)
+    df.show
+    assert(df.count() == 256)
+  }
+
   test("empty column") {
     val df = withCatalog(catalog)
     df.registerTempTable("table0")

--- a/core/src/test/scala/org/apache/spark/sql/PhoenixSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/PhoenixSuite.scala
@@ -114,9 +114,10 @@ class PhoenixSuite extends SHC with Logging {
   test("IN and Not IN filter1") {
     val df = withCatalog(catalog)
     val s = df.filter(($"col0" isin ("row005", "row001", "row002")) and !($"col0" isin ("row001", "row002")))
-      .select("col0")
+      .select("col0", "col8")
     s.explain(true)
     s.show
     assert(s.count() == 1)
+    assert(s.first().getByte(1) == 5)
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/PhoenixSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/PhoenixSuite.scala
@@ -102,6 +102,7 @@ class PhoenixSuite extends SHC with Logging {
     val df = withCatalog(catalog)
     df.show
     assert(df.count() == 256)
+    assert(df.first().getByte(8) == 0)
   }
 
   test("empty column") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Type`tinyint` in Phoenix is mapped to `java.lang.Byte` in Java. When using phoenix coder to encode or decode data, we should use `PTinyint.INSTANCE`.
Reproduce:
Save `i.toByte` ( `i` is int 1 : "`val i: Int = 1`") to HBase with Phoenix as the data coder, and then read it back and print it. The result will be `-127` which is not current. The correct result should be `1`.

2. For `Array[Byte] `which is mapping to `BinaryType `in Spark, we should use `PVarbinary.INSTANCE  ` instead of `PBinary.INSTANCE`. 

## How was this patch tested?
Pass the current unit tests.

Also , for the first change, run the `test("full query")` in `PhoenixSuite`. Check the last column `col8`, where the data should be from 0 to 255.

**BEFORE**
```
+------+-----+-----+----+----+----+----+----+--------------+----+
| col00|col01| col1|col2|col3|col4|col5|col6|          col7|col8|
+------+-----+-----+----+----+----+----+----+--------------+----+
|row000|    0| true| 0.0| 0.0|   0|   0|   0| String0 extra|-128|
|row001|   -1|false| 1.0| 1.0|   1|   1|   1| String1 extra|-127|
|row002|    2| true| 2.0| 2.0|   2|   2|   2| String2 extra|-126|
|row003|   -3|false| 3.0| 3.0|   3|   3|   3| String3 extra|-125|
|row004|    4| true| 4.0| 4.0|   4|   4|   4| String4 extra|-124|
|row005|   -5|false| 5.0| 5.0|   5|   5|   5| String5 extra|-123|
|row006|    6| true| 6.0| 6.0|   6|   6|   6| String6 extra|-122|
|row007|   -7|false| 7.0| 7.0|   7|   7|   7| String7 extra|-121|
|row008|    8| true| 8.0| 8.0|   8|   8|   8| String8 extra|-120|
|row009|   -9|false| 9.0| 9.0|   9|   9|   9| String9 extra|-119|
|row010|   10| true|10.0|10.0|  10|  10|  10|String10 extra|-118|
|row011|  -11|false|11.0|11.0|  11|  11|  11|String11 extra|-117|
|row012|   12| true|12.0|12.0|  12|  12|  12|String12 extra|-116|
|row013|  -13|false|13.0|13.0|  13|  13|  13|String13 extra|-115|
|row014|   14| true|14.0|14.0|  14|  14|  14|String14 extra|-114|
|row015|  -15|false|15.0|15.0|  15|  15|  15|String15 extra|-113|
|row016|   16| true|16.0|16.0|  16|  16|  16|String16 extra|-112|
|row017|  -17|false|17.0|17.0|  17|  17|  17|String17 extra|-111|
|row018|   18| true|18.0|18.0|  18|  18|  18|String18 extra|-110|
|row019|  -19|false|19.0|19.0|  19|  19|  19|String19 extra|-109|
+------+-----+-----+----+----+----+----+----+--------------+----+
only showing top 20 rows
```

**AFTER**
```
+------+-----+-----+----+----+----+----+----+--------------+----+
| col00|col01| col1|col2|col3|col4|col5|col6|          col7|col8|
+------+-----+-----+----+----+----+----+----+--------------+----+
|row000|    0| true| 0.0| 0.0|   0|   0|   0| String0 extra|   0|
|row001|   -1|false| 1.0| 1.0|   1|   1|   1| String1 extra|   1|
|row002|    2| true| 2.0| 2.0|   2|   2|   2| String2 extra|   2|
|row003|   -3|false| 3.0| 3.0|   3|   3|   3| String3 extra|   3|
|row004|    4| true| 4.0| 4.0|   4|   4|   4| String4 extra|   4|
|row005|   -5|false| 5.0| 5.0|   5|   5|   5| String5 extra|   5|
|row006|    6| true| 6.0| 6.0|   6|   6|   6| String6 extra|   6|
|row007|   -7|false| 7.0| 7.0|   7|   7|   7| String7 extra|   7|
|row008|    8| true| 8.0| 8.0|   8|   8|   8| String8 extra|   8|
|row009|   -9|false| 9.0| 9.0|   9|   9|   9| String9 extra|   9|
|row010|   10| true|10.0|10.0|  10|  10|  10|String10 extra|  10|
|row011|  -11|false|11.0|11.0|  11|  11|  11|String11 extra|  11|
|row012|   12| true|12.0|12.0|  12|  12|  12|String12 extra|  12|
|row013|  -13|false|13.0|13.0|  13|  13|  13|String13 extra|  13|
|row014|   14| true|14.0|14.0|  14|  14|  14|String14 extra|  14|
|row015|  -15|false|15.0|15.0|  15|  15|  15|String15 extra|  15|
|row016|   16| true|16.0|16.0|  16|  16|  16|String16 extra|  16|
|row017|  -17|false|17.0|17.0|  17|  17|  17|String17 extra|  17|
|row018|   18| true|18.0|18.0|  18|  18|  18|String18 extra|  18|
|row019|  -19|false|19.0|19.0|  19|  19|  19|String19 extra|  19|
+------+-----+-----+----+----+----+----+----+--------------+----+
only showing top 20 rows
```


