### PR TITLE
Make users able to specify which namespace they want to use for their tables

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/PhoenixSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/PhoenixSuite.scala
@@ -61,7 +61,7 @@ object PRecord {
 
 class PhoenixSuite extends SHC with Logging {
   override def catalog = s"""{
-                    |"table":{"namespace":"default", "name":"table1", "tableCoder":"Phoenix"},
+                    |"table":{"namespace":"phoenixSpace", "name":"phoenixTable", "tableCoder":"Phoenix"},
                     |"rowkey":"key",
                     |"columns":{
                     |"col0":{"cf":"rowkey", "col":"key", "type":"string"},


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is to make users able to specify which namespace they want to use for their tables.

## How was this patch tested?
1. Pass unit tests. 
2. Run some example in HDP cluster locally, and check if the `Namespace` showing in the HBase Master UI is the same with the `namespace` specified in the catalog.