### PR TITLE
Add support for specifying HBase configuration file via datasource options

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.hbase
 import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 
 import scala.util.control.NonFatal
+import scala.xml.XML
 
 import org.json4s.DefaultFormats
 import org.json4s.jackson.JsonMethods._
@@ -86,8 +87,20 @@ case class HBaseRelation(
         val hBaseConfiguration = parameters.get(HBaseRelation.HBASE_CONFIGURATION).map(
           parse(_).extract[Map[String, String]])
 
+        val cFile = parameters.get(HBaseRelation.HBASE_CONFIGFILE)
+        val hBaseConfigFile = {
+          var confMap: Map[String, String] = Map.empty
+          if (cFile.isDefined) {
+            val xmlFile = XML.loadFile(cFile.get)
+            (xmlFile \\ "property").foreach(
+              x => { confMap += ((x \ "name").text -> (x \ "value").text) })
+          }
+          confMap
+        }
+
         val conf = HBaseConfiguration.create
         hBaseConfiguration.foreach(_.foreach(e => conf.set(e._1, e._2)))
+        hBaseConfigFile.foreach(e => conf.set(e._1, e._2))
         conf
       }
     }
@@ -281,4 +294,6 @@ object HBaseRelation {
   val MAX_STAMP = "maxStamp"
   val MAX_VERSIONS = "maxVersions"
   val HBASE_CONFIGURATION = "hbaseConfiguration"
+  // HBase configuration file such as HBase-site.xml, core-site.xml
+  val HBASE_CONFIGFILE = "hbaseConfigFile"
 }

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/AvroSource.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/AvroSource.scala
@@ -91,7 +91,7 @@ object AvroSource {
                               |}""".stripMargin
 
   def main(args: Array[String]) {
-    val sparkConf = new SparkConf().setAppName("AvroTest")
+    val sparkConf = new SparkConf().setAppName("AvroExample")
     val sc = new SparkContext(sparkConf)
     val sqlContext = new SQLContext(sc)
 

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/CompositeKey.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/CompositeKey.scala
@@ -71,7 +71,7 @@ object CompositeKey {
                     |}""".stripMargin
 
   def main(args: Array[String]){
-    val sparkConf = new SparkConf().setAppName("CompositeKeyTest")
+    val sparkConf = new SparkConf().setAppName("CompositeKeyExample")
     val sc = new SparkContext(sparkConf)
     val sqlContext = new SQLContext(sc)
 

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/DataType.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/DataType.scala
@@ -64,7 +64,7 @@ object DataType {
                     |}""".stripMargin
 
   def main(args: Array[String]){
-    val sparkConf = new SparkConf().setAppName("DataTypeTest")
+    val sparkConf = new SparkConf().setAppName("DataTypeExample")
     val sc = new SparkContext(sparkConf)
     val sqlContext = new SQLContext(sc)
 

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseSource.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseSource.scala
@@ -81,7 +81,7 @@ object HBaseSource {
                 |}""".stripMargin
 
   def main(args: Array[String]) {
-    val sparkConf = new SparkConf().setAppName("HBaseTest")
+    val sparkConf = new SparkConf().setAppName("HBaseSourceExample")
     val sc = new SparkContext(sparkConf)
     val sqlContext = new SQLContext(sc)
 
@@ -91,15 +91,6 @@ object HBaseSource {
       sqlContext
         .read
         .options(Map(HBaseTableCatalog.tableCatalog->cat))
-        .format("org.apache.spark.sql.execution.datasources.hbase")
-        .load()
-    }
-
-    // for testing connection sharing only
-    def withCatalog1(cat: String): DataFrame = {
-      sqlContext
-        .read
-        .options(Map(HBaseTableCatalog.tableCatalog->cat1))
         .format("org.apache.spark.sql.execution.datasources.hbase")
         .load()
     }

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/JoinTablesFrom2Clusters.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/JoinTablesFrom2Clusters.scala
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.hbase.examples
+
+import org.apache.spark.sql.execution.datasources.hbase.{HBaseRelation, HBaseTableCatalog}
+import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.{SparkContext, SparkConf}
+
+case class JRecord(
+    col0: String,
+    col1: Boolean,
+    col2: Double,
+    col3: Float,
+    col4: Int,
+    col5: Long,
+    col6: Short,
+    col7: String,
+    col8: Byte)
+
+object JRecord {
+  def apply(i: Int): JRecord = {
+    val s = s"""row${"%03d".format(i)}"""
+    JRecord(s,
+      i % 2 == 0,
+      i.toDouble,
+      i.toFloat,
+      i,
+      i.toLong,
+      i.toShort,
+      s"String$i extra",
+      i.toByte)
+  }
+}
+
+object JoinTablesFrom2Clusters {
+  val cat1 = s"""{
+                |"table":{"namespace":"default", "name":"shcExampleTable1", "tableCoder":"PrimitiveType"},
+                |"rowkey":"key",
+                |"columns":{
+                |"col0":{"cf":"rowkey", "col":"key", "type":"string"},
+                |"col1":{"cf":"cf1", "col":"col1", "type":"boolean"},
+                |"col2":{"cf":"cf2", "col":"col2", "type":"double"},
+                |"col3":{"cf":"cf3", "col":"col3", "type":"float"},
+                |"col4":{"cf":"cf4", "col":"col4", "type":"int"},
+                |"col5":{"cf":"cf5", "col":"col5", "type":"bigint"},
+                |"col6":{"cf":"cf6", "col":"col6", "type":"smallint"},
+                |"col7":{"cf":"cf7", "col":"col7", "type":"string"},
+                |"col8":{"cf":"cf8", "col":"col8", "type":"tinyint"}
+                |}
+                |}""".stripMargin
+
+  val cat2 = s"""{
+                |"table":{"namespace":"default", "name":"shcExampleTable2", "tableCoder":"PrimitiveType"},
+                |"rowkey":"key",
+                |"columns":{
+                |"col0":{"cf":"rowkey", "col":"key", "type":"string"},
+                |"col1":{"cf":"cf1", "col":"col1", "type":"boolean"},
+                |"col2":{"cf":"cf2", "col":"col2", "type":"double"},
+                |"col3":{"cf":"cf3", "col":"col3", "type":"float"},
+                |"col4":{"cf":"cf4", "col":"col4", "type":"int"},
+                |"col5":{"cf":"cf5", "col":"col5", "type":"bigint"},
+                |"col6":{"cf":"cf6", "col":"col6", "type":"smallint"},
+                |"col7":{"cf":"cf7", "col":"col7", "type":"string"},
+                |"col8":{"cf":"cf8", "col":"col8", "type":"tinyint"}
+                |}
+                |}""".stripMargin
+
+
+  def main(args: Array[String]): Unit = {
+    if (args.length < 2) {
+      System.err.println("Usage: JoinTablesFrom2Clusters <configurationFile1> <configurationFile1>")
+      System.exit(1)
+    }
+
+    val sparkConf = new SparkConf().setAppName("JoinTablesFrom2Clusters")
+    val sc = new SparkContext(sparkConf)
+    val sqlContext = new SQLContext(sc)
+
+    // configuration file of HBase cluster
+    val conf1 = args(0)
+    val conf2 = args(1)
+
+    import sqlContext.implicits._
+
+    def withCatalog(cat: String, conf: String): DataFrame = {
+      sqlContext
+        .read
+        .options(Map(HBaseTableCatalog.tableCatalog->cat, HBaseRelation.HBASE_CONFIGFILE -> conf))
+        .format("org.apache.spark.sql.execution.datasources.hbase")
+        .load()
+    }
+
+    def saveData(cat: String, conf: String, data: Seq[JRecord]) = {
+      sc.parallelize(data).toDF.write
+        .options(Map(HBaseTableCatalog.tableCatalog -> cat,
+          HBaseRelation.HBASE_CONFIGFILE -> conf, HBaseTableCatalog.newTable -> "5"))
+        .format("org.apache.spark.sql.execution.datasources.hbase")
+        .save()
+    }
+
+    // data saved into cluster 1
+    val data1 = (0 to 120).map { i =>
+      JRecord(i)
+    }
+    saveData(cat1, conf1, data1)
+
+    // data saved into cluster 2
+    val data2 = (100 to 200).map { i =>
+      JRecord(i)
+    }
+    saveData(cat2, conf2, data2)
+
+    val df1 = withCatalog(cat1, conf1)
+    val df2 = withCatalog(cat2, conf2)
+    val s1 = df1.filter($"col0" <= "row120" && $"col0" > "row090").select("col0", "col2")
+    val s2 = df2.filter($"col0" <= "row150" && $"col0" > "row100").select("col0", "col5")
+    val result =  s1.join(s2, Seq("col0")).cache
+
+    result.show()  // should be row101 to row120, as following:
+    /*+------+-----+----+
+      |  col0| col2|col5|
+      +------+-----+----+
+      |row120|120.0| 120|
+      |row101|101.0| 101|
+      |row102|102.0| 102|
+      |row103|103.0| 103|
+      |row104|104.0| 104|
+      |row105|105.0| 105|
+      |row106|106.0| 106|
+      |row107|107.0| 107|
+      |row108|108.0| 108|
+      |row109|109.0| 109|
+      |row110|110.0| 110|
+      |row111|111.0| 111|
+      |row112|112.0| 112|
+      |row113|113.0| 113|
+      |row114|114.0| 114|
+      |row115|115.0| 115|
+      |row116|116.0| 116|
+      |row117|117.0| 117|
+      |row118|118.0| 118|
+      |row119|119.0| 119|
+      +------+-----+----+ */
+
+    println(result.count()) // should be 20
+
+    sc.stop()
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Add support for specifying HBase configuration file via datasource options
2. Update App names in examples
3. Add an example for access 2 HBase clusters in 2 queries concurrently in a spark job

## How was this patch tested?
Pass the unit tests; Test the added example in HDP cluster.