### PR TITLE
Return exception when HBaseTableCatalog.newTable <= 3

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
@@ -63,6 +63,9 @@ private[sql] class DefaultSource extends RelationProvider with CreatableRelation
   }
 }
 
+case class InvalidRegionNumberException(message: String = "", cause: Throwable = null)
+              extends Exception(message, cause) 
+
 case class HBaseRelation(
     parameters: Map[String, String],
     userSpecifiedschema: Option[StructType]
@@ -158,6 +161,9 @@ case class HBaseRelation(
       }
       admin.close()
       connection.close()
+    }
+    else {
+        throw new InvalidRegionNumberException("Number of regions specified for new table must be greater than 3.")
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Return an exception when the option HBaseTableCatalog.newTable <= 3. Previously, no exception would be returned, and a downstream failure would occur when the HBase API could not find a table with the specified name.

## How was this patch tested?

I manually tested the patch by specifiying write code like this:
`        sqlRes.write.options(
                Map(HBaseTableCatalog.tableCatalog -> catalogTestWrite, HBaseTableCatalog.newTable -> "3"))
        .format("org.apache.spark.sql.execution.datasources.hbase")
        .save()
`

and confirming that the exception was thrown, and then by changing it to "5" and confirming that the table was written.