### PR TITLE
Wrong argument is being passed to constructor of custom data type

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/SHCDataType.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/SHCDataType.scala
@@ -73,7 +73,7 @@ object SHCDataTypeFactory {
       // Data type implemented by user
       Class.forName(f.fCoder)
         .getConstructor(classOf[Option[Field]])
-        .newInstance(f.fCoder)
+        .newInstance(Some(f))
         .asInstanceOf[SHCDataType]
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

To fix the argument passed to the constructor of a custom data type

## How was this patch tested?

All existing unit tests still pass