### PR TITLE
Fix serialization in scanrange

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
@@ -152,7 +152,7 @@ case class HBaseRelation(
         val endKey = catalog.shcTableCoder.toBytes("zzzzzzz")
         val splitKeys = Bytes.split(startKey, endKey, catalog.numReg - 3)
         admin.createTable(tableDesc, splitKeys)
-        val r = connection.getRegionLocator(TableName.valueOf(catalog.name)).getAllRegionLocations
+        val r = connection.getRegionLocator(tName).getAllRegionLocations
         while(r == null || r.size() == 0) {
           logDebug(s"region not allocated")
           Thread.sleep(1000)
@@ -174,7 +174,7 @@ case class HBaseRelation(
    * @param overwrite Overwrite existing values
    */
   override def insert(data: DataFrame, overwrite: Boolean): Unit = {
-    hbaseConf.set(TableOutputFormat.OUTPUT_TABLE, catalog.name)
+    hbaseConf.set(TableOutputFormat.OUTPUT_TABLE, s"${catalog.namespace}:${catalog.name}")
     val job = Job.getInstance(hbaseConf)
     job.setOutputFormatClass(classOf[TableOutputFormat[String]])
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseResources.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseResources.scala
@@ -91,7 +91,7 @@ case class RegionResource(relation: HBaseRelation) extends ReferencedResource {
 
   override def init(): Unit = {
     connection = HBaseConnectionCache.getConnection(relation.hbaseConf)
-    rl = connection.getRegionLocator(TableName.valueOf(relation.catalog.name))
+    rl = connection.getRegionLocator(TableName.valueOf(relation.catalog.namespace, relation.catalog.name))
   }
 
   override def destroy(): Unit = {
@@ -123,7 +123,7 @@ case class TableResource(relation: HBaseRelation) extends ReferencedResource {
 
   override def init(): Unit = {
     connection = HBaseConnectionCache.getConnection(relation.hbaseConf)
-    table = connection.getTable(TableName.valueOf(relation.catalog.name))
+    table = connection.getTable(TableName.valueOf(relation.catalog.namespace, relation.catalog.name))
   }
 
   override def destroy(): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/ScanRange.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/ScanRange.scala
@@ -413,28 +413,10 @@ object BoundRange extends Logging{
           Some(BoundRanges(Array(BoundRange(min, b)),Array(BoundRange(b, max)), b))
         }
 
-      case a: Array[Byte] =>
+      case _: Array[Byte] | _: Byte | _: String | _: UTF8String =>
         Some(BoundRanges(
-          Array(BoundRange(Array.fill(a.length)(ByteMin), a)),
-          Array(BoundRange(a, Array.fill(a.length)(ByteMax))), a))
-
-      case a: Byte =>
-        val b =  Array(a)
-        Some(BoundRanges(
-          Array(BoundRange(Array(ByteMin), b)),
-          Array(BoundRange(b, Array(ByteMax))), b))
-
-      case a: String =>
-        val b =  Bytes.toBytes(a)
-        Some(BoundRanges(
-          Array(BoundRange(Array.fill(a.length)(ByteMin), b)),
-          Array(BoundRange(b, Array.fill(a.length)(ByteMax))), b))
-
-      case a: UTF8String =>
-        val b = a.getBytes
-        Some(BoundRanges(
-          Array(BoundRange(Array.fill(a.numBytes())(ByteMin), b)),
-          Array(BoundRange(b, Array.fill(a.numBytes())(ByteMax))), b))
+          Array(BoundRange(Array.fill(b.length)(ByteMin), b)),
+          Array(BoundRange(b, Array.fill(b.length)(ByteMax))), b))
 
       case _ => None
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The calculation of the range for the scanner is not correct for types String, Array[Byte], Byte, UTF8String.  The serialized representations should be obtained from the coder.  In the case of PrimitiveType and Phoenix, the serializations happen to match the code in ScanRange.scala.  However, I have a custom coder that does not have the same serialization.

## How was this patch tested?

All existing unit tests still pass
