### PR TITLE
Add examples for long running tests

### DIFF
--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/CompositeKey.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/CompositeKey.scala
@@ -18,8 +18,7 @@
 package org.apache.spark.sql.execution.datasources.hbase.examples
 
 import org.apache.spark.sql.execution.datasources.hbase._
-import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.sql.{SparkSession, SQLContext, DataFrame}
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
 case class HBaseCompositeRecord(
     col00: String,

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/DataCoder.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/DataCoder.scala
@@ -18,8 +18,7 @@
 package org.apache.spark.sql.execution.datasources.hbase.examples
 
 import org.apache.spark.sql.execution.datasources.hbase._
-import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.sql.{SQLContext, DataFrame}
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
 case class DCRecord(
     col00: String,
@@ -71,9 +70,12 @@ object DataCoder {
                 |}""".stripMargin
 
   def main(args: Array[String]){
-    val sparkConf = new SparkConf().setAppName("DataCoderExample")
-    val sc = new SparkContext(sparkConf)
-    val sqlContext = new SQLContext(sc)
+    val spark = SparkSession.builder()
+      .appName("DataCoderExample")
+      .getOrCreate()
+
+    val sc = spark.sparkContext
+    val sqlContext = spark.sqlContext
 
     import sqlContext.implicits._
 

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/DataType.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/DataType.scala
@@ -17,8 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.hbase.examples
 
-import org.apache.spark.sql.{SparkSession, DataFrame, SQLContext}
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{SparkSession, DataFrame}
 import org.apache.spark.sql.execution.datasources.hbase._
 
 case class IntKeyRecord(

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseSource.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseSource.scala
@@ -17,9 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources.hbase.examples
 
-import org.apache.spark.sql.{SQLContext, _}
 import org.apache.spark.sql.execution.datasources.hbase._
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
 case class HBaseRecord(
     col0: String,

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/LRJobAccessing2Clusters.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/LRJobAccessing2Clusters.scala
@@ -83,13 +83,14 @@ object LRJobAccessing2Clusters {
 
   def main(args: Array[String]): Unit = {
     if (args.length < 2) {
-      System.err.println("Usage: LRJobAccessing2Clusters <configurationFile1> <configurationFile2>")
+      System.err.println("Usage: LRJobAccessing2Clusters <configurationFile1> <configurationFile2> [sleepTime]")
       System.exit(1)
     }
 
     // configuration file of HBase cluster
     val conf1 = args(0)
     val conf2 = args(1)
+    val sleepTime = if (args.length > 2) args(2).toLong else 2 * 60 * 1000 // sleep 2 min by default
 
     val spark = SparkSession.builder()
       .appName("LRJobAccessing2Clusters")
@@ -164,7 +165,7 @@ object LRJobAccessing2Clusters {
 
       println(result.count()) // should be 20
 
-      Thread.sleep(60 * 1000) // sleep 1 min
+      Thread.sleep(sleepTime)
     }
     sc.stop()
   }

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/LRJobAccessing2Clusters.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/LRJobAccessing2Clusters.scala
@@ -163,6 +163,8 @@ object LRJobAccessing2Clusters {
       +------+-----+----+ */
 
       println(result.count()) // should be 20
+
+      Thread.sleep(60 * 1000) // sleep 1 min
     }
     sc.stop()
   }

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/LRJobForDataSources.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/LRJobForDataSources.scala
@@ -68,18 +68,19 @@ object LRJobForDataSources {
         .load()
     }
 
-    val timeEnd = System.currentTimeMillis() + (25 * 60 * 60 * 1000) // 25h later
-    while (System.currentTimeMillis() < timeEnd) {
+    // val timeEnd = System.currentTimeMillis() + (25 * 60 * 60 * 1000) // 25h later
+    // while (System.currentTimeMillis() < timeEnd) {
       // Part 1: write data into Hive table and read data from it, which accesses HDFS
       sql("DROP TABLE IF EXISTS shcHiveTable")
       sql("CREATE TABLE shcHiveTable(key INT, col1 BOOLEAN, col2 DOUBLE, col3 FLOAT)")
-      for (i <- 1 to 10) {
+      for (i <- 1 to 2) {
         sql(s"INSERT INTO shcHiveTable VALUES ($i, ${i % 2 == 0}, ${i.toDouble}, ${i.toFloat})")
         sql("SELECT COUNT(*) FROM shcHiveTable").show()
+       // sql("SELECT COUNT(*) FROM shcHiveTable").explain()
       }
 
       // Part 2: create HBase table, write data into it, read data from it
-      val data = (0 to 40).map { i =>
+ /*     val data = (0 to 40).map { i =>
         LRRecord(i)
       }
       sc.parallelize(data).toDF.write.options(
@@ -96,10 +97,10 @@ object LRJobForDataSources {
         .select($"col0", $"col1").show
       df.createOrReplaceTempView("table1")
       val c = sqlContext.sql("select count(col1) from table1 where col0 < '20'")
-      c.show()
+      c.show()*/
 
       Thread.sleep(60 * 1000) // sleep 1 min
-    }
+   // }
 
     spark.stop()
   }

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/LRJobForDataSources.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/LRJobForDataSources.scala
@@ -50,7 +50,7 @@ object LRJobForDataSources {
 
   def main(args: Array[String]) {
     val spark = SparkSession.builder()
-      .appName("LRJobHBaseSources")
+      .appName("LRJobForDataSources")
       .enableHiveSupport()
       .getOrCreate()
 
@@ -73,7 +73,7 @@ object LRJobForDataSources {
       // Part 1: write data into Hive table and read data from it, which accesses HDFS
       sql("DROP TABLE IF EXISTS shcHiveTable")
       sql("CREATE TABLE shcHiveTable(key INT, col1 BOOLEAN, col2 DOUBLE, col3 FLOAT)")
-      for (i <- 1 to 20) {
+      for (i <- 1 to 10) {
         sql(s"INSERT INTO shcHiveTable VALUES ($i, ${i % 2 == 0}, ${i.toDouble}, ${i.toFloat})")
         sql("SELECT COUNT(*) FROM shcHiveTable").show()
       }

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/LRJobForDataSources.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/LRJobForDataSources.scala
@@ -68,18 +68,17 @@ object LRJobForDataSources {
         .load()
     }
 
-    sql("DROP TABLE IF EXISTS shcHiveTable")
-    sql("CREATE TABLE shcHiveTable(key INT, col1 BOOLEAN, col2 DOUBLE, col3 FLOAT)")
-
     val timeEnd = System.currentTimeMillis() + (25 * 60 * 60 * 1000) // 25h later
     while (System.currentTimeMillis() < timeEnd) {
       // Part 1: write data into Hive table and read data from it, which accesses HDFS
-      for (i <- 1 to 40) {
+      sql("DROP TABLE IF EXISTS shcHiveTable")
+      sql("CREATE TABLE shcHiveTable(key INT, col1 BOOLEAN, col2 DOUBLE, col3 FLOAT)")
+      for (i <- 1 to 20) {
         sql(s"INSERT INTO shcHiveTable VALUES ($i, ${i % 2 == 0}, ${i.toDouble}, ${i.toFloat})")
         sql("SELECT COUNT(*) FROM shcHiveTable").show()
       }
 
-      // Part2: create HBase table, write data into it, read data from it
+      // Part 2: create HBase table, write data into it, read data from it
       val data = (0 to 40).map { i =>
         LRRecord(i)
       }
@@ -98,6 +97,8 @@ object LRJobForDataSources {
       df.createOrReplaceTempView("table1")
       val c = sqlContext.sql("select count(col1) from table1 where col0 < '20'")
       c.show()
+
+      Thread.sleep(60 * 1000) // sleep 1 min
     }
 
     spark.stop()

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/LRJobForDataSources.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/LRJobForDataSources.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.hbase.examples
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.execution.datasources.hbase.{HBaseRelation, HBaseTableCatalog}
+
+case class LRRecord(
+    col0: Int,
+    col1: Boolean,
+    col2: Double,
+    col3: Float)
+
+object LRRecord {
+  def apply(i: Int): LRRecord = {
+    LRRecord(i,
+      i % 2 == 0,
+      i.toDouble,
+      i.toFloat)
+  }
+}
+
+// long running job for different data sources
+object LRJobForDataSources {
+  val cat = s"""{
+            |"table":{"namespace":"default", "name":"shcExampleTable", "tableCoder":"PrimitiveType"},
+            |"rowkey":"key",
+            |"columns":{
+              |"col0":{"cf":"rowkey", "col":"key", "type":"int"},
+              |"col1":{"cf":"cf1", "col":"col1", "type":"boolean"},
+              |"col2":{"cf":"cf2", "col":"col2", "type":"double"},
+              |"col3":{"cf":"cf3", "col":"col3", "type":"float"}
+            |}
+          |}""".stripMargin
+
+  def main(args: Array[String]) {
+    val spark = SparkSession.builder()
+      .appName("LRJobHBaseSources")
+      .enableHiveSupport()
+      .getOrCreate()
+
+    val sc = spark.sparkContext
+    val sqlContext = spark.sqlContext
+
+    import sqlContext.implicits._
+    import spark.sql
+
+    def withCatalog(cat: String): DataFrame = {
+      sqlContext
+        .read
+        .options(Map(HBaseTableCatalog.tableCatalog->cat))
+        .format("org.apache.spark.sql.execution.datasources.hbase")
+        .load()
+    }
+
+    sql("DROP TABLE IF EXISTS shcHiveTable")
+    sql("CREATE TABLE shcHiveTable(key INT, col1 BOOLEAN, col2 DOUBLE, col3 FLOAT)")
+
+    val timeEnd = System.currentTimeMillis() + (25 * 60 * 60 * 1000) // 25h later
+    while (System.currentTimeMillis() < timeEnd) {
+      // Part 1: write data into Hive table and read data from it, which accesses HDFS
+      for (i <- 1 to 40) {
+        sql(s"INSERT INTO shcHiveTable VALUES ($i, ${i % 2 == 0}, ${i.toDouble}, ${i.toFloat})")
+        sql("SELECT COUNT(*) FROM shcHiveTable").show()
+      }
+
+      // Part2: create HBase table, write data into it, read data from it
+      val data = (0 to 40).map { i =>
+        LRRecord(i)
+      }
+      sc.parallelize(data).toDF.write.options(
+        Map(HBaseTableCatalog.tableCatalog -> cat, HBaseTableCatalog.newTable -> "5"))
+        .format("org.apache.spark.sql.execution.datasources.hbase")
+        .save()
+      val df = withCatalog(cat)
+      df.show
+      df.filter($"col0" <= "5")
+        .select($"col0", $"col1").show
+      df.filter($"col0" === "5" || $"col0" <= "5")
+        .select($"col0", $"col1").show
+      df.filter($"col0" > "10")
+        .select($"col0", $"col1").show
+      df.createOrReplaceTempView("table1")
+      val c = sqlContext.sql("select count(col1) from table1 where col0 < '20'")
+      c.show()
+    }
+
+    spark.stop()
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Code clean: 

- Remove useless `import`;
- Use `SparkSession.builder()` instead of `new SparkConf().setAppName()`.

3.  Add two long running examples:

- The example `LRJobAccessing2Clusters` is to access two HBase clusters. 
- The example `LRJobForDataSources` is to write/read data from Hive table (it will access HDFS), and write/read data from HBase table.

## How was this patch tested?
Build pass. Current existing unit tests. Testing the examples in a single secure cluster (25h).
