### PR TITLE
Handle varargs when using reflection from scala

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/SHCDataType.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/SHCDataType.scala
@@ -72,8 +72,8 @@ object SHCDataTypeFactory {
     } else {
       // Data type implemented by user
       Class.forName(f.fCoder)
-        .getConstructor(classOf[Option[Field]])
-        .newInstance(Some(f))
+        .getConstructor(Array(classOf[Option[Field]]):_*)
+        .newInstance(Array(Some(f)):_*)
         .asInstanceOf[SHCDataType]
     }
   }


### PR DESCRIPTION
Fixed an issue where "IllegalArgumentException: argument type mismatch" was raised when a custom coder was used.

The methods getConstructor and newInstance accept variable arguments.
While invoking from scala it should be converted to varargs reference.
All unit tests passed.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
