### PR TITLE
Fix SPARK-21549 in SHC side

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
@@ -183,7 +183,9 @@ case class HBaseRelation(
     // This is a workaround for SPARK-21549. After it is fixed, the snippet can be removed.
     val jobConfig = job.getConfiguration
     val tempDir = Utils.createTempDir()
-    jobConfig.set("mapreduce.output.fileoutputformat.outputdir", tempDir.getPath + "/outputDataset")
+    if (jobConfig.get("mapreduce.output.fileoutputformat.outputdir") == null) {
+      jobConfig.set("mapreduce.output.fileoutputformat.outputdir", tempDir.getPath + "/outputDataset")
+    }
 
     var count = 0
     val rkFields = catalog.getRowKey


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix SPARK-21549 in SHC side. Set `mapreduce.output.fileoutputformat.outputdir` in insert().

## How was this patch tested?
Passed current unit tests and manually testing in HDP clusters.