### PR TITLE
add support for multiple versions

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
@@ -155,6 +155,7 @@ case class HBaseRelation(
       cfs.foreach { x =>
         val cf = new HColumnDescriptor(x.getBytes())
         logDebug(s"add family $x to ${catalog.name}")
+        cf.setMaxVersions(catalog.maxVersions)
         tableDesc.addFamily(cf)
       }
       val startKey = catalog.shcTableCoder.toBytes("aaaaaaa")
@@ -322,6 +323,7 @@ object HBaseRelation {
   val TIMESTAMP = "timestamp"
   val MIN_STAMP = "minStamp"
   val MAX_STAMP = "maxStamp"
+  val MARGE_TO_LATEST = "latest"
   val MAX_VERSIONS = "maxVersions"
   val HBASE_CONFIGURATION = "hbaseConfiguration"
   // HBase configuration file such as HBase-site.xml, core-site.xml

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
@@ -79,7 +79,8 @@ case class HBaseRelation(
   val timestamp = parameters.get(HBaseRelation.TIMESTAMP).map(_.toLong)
   val minStamp = parameters.get(HBaseRelation.MIN_STAMP).map(_.toLong)
   val maxStamp = parameters.get(HBaseRelation.MAX_STAMP).map(_.toLong)
-  val maxVersions = parameters.get(HBaseRelation.MAX_VERSIONS).map(_.toInt)
+  val maxVersions = parameters.get(HBaseRelation.MAX_VERSIONS).map(_.toInt)//.getOrElse(Int.MaxValue)
+  val margeToLatest = parameters.get(HBaseRelation.MARGE_TO_LATEST).map(_.toBoolean).getOrElse(true)
 
   val catalog = HBaseTableCatalog(parameters)
 
@@ -155,7 +156,7 @@ case class HBaseRelation(
       cfs.foreach { x =>
         val cf = new HColumnDescriptor(x.getBytes())
         logDebug(s"add family $x to ${catalog.name}")
-        cf.setMaxVersions(catalog.maxVersions)
+        maxVersions.foreach(v => cf.setMaxVersions(v))
         tableDesc.addFamily(cf)
       }
       val startKey = catalog.shcTableCoder.toBytes("aaaaaaa")

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
@@ -79,8 +79,8 @@ case class HBaseRelation(
   val timestamp = parameters.get(HBaseRelation.TIMESTAMP).map(_.toLong)
   val minStamp = parameters.get(HBaseRelation.MIN_STAMP).map(_.toLong)
   val maxStamp = parameters.get(HBaseRelation.MAX_STAMP).map(_.toLong)
-  val maxVersions = parameters.get(HBaseRelation.MAX_VERSIONS).map(_.toInt)//.getOrElse(Int.MaxValue)
-  val margeToLatest = parameters.get(HBaseRelation.MARGE_TO_LATEST).map(_.toBoolean).getOrElse(true)
+  val maxVersions = parameters.get(HBaseRelation.MAX_VERSIONS).map(_.toInt)
+  val mergeToLatest = parameters.get(HBaseRelation.MERGE_TO_LATEST).map(_.toBoolean).getOrElse(true)
 
   val catalog = HBaseTableCatalog(parameters)
 
@@ -324,7 +324,7 @@ object HBaseRelation {
   val TIMESTAMP = "timestamp"
   val MIN_STAMP = "minStamp"
   val MAX_STAMP = "maxStamp"
-  val MARGE_TO_LATEST = "latest"
+  val MERGE_TO_LATEST = "mergeToLatest"
   val MAX_VERSIONS = "maxVersions"
   val HBASE_CONFIGURATION = "hbaseConfiguration"
   // HBase configuration file such as HBase-site.xml, core-site.xml

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
@@ -167,7 +167,9 @@ case class HBaseTableCatalog(
     sMap: SchemaMap,
     tCoder: String,
     coderSet: Set[String],
-    val numReg: Int) extends Logging {
+    val numReg: Int,
+    maxVersions: Int,
+    latest: Boolean) extends Logging {
   def toDataType = StructType(sMap.toFields)
   def getField(name: String) = sMap.getField(name)
   def getRowKey: Seq[Field] = row.fields
@@ -262,6 +264,8 @@ object HBaseTableCatalog {
     val tableMeta = map.get(table).get.asInstanceOf[Map[String, _]]
     val nSpace = tableMeta.get(nameSpace).getOrElse("default").asInstanceOf[String]
     val tName = tableMeta.get(tableName).get.asInstanceOf[String]
+    val maxVersions = parameters.get(HBaseRelation.MAX_VERSIONS).map(_.toInt).getOrElse(Int.MaxValue)
+    val latest = parameters.get(HBaseRelation.MARGE_TO_LATEST).map(_.toBoolean).getOrElse(true)
 
     // Since the catalog version 2.0, SHC supports Phoenix as coder.
     // If the catalog version specified by users is equal or later than 2.0, tableCoder must be specified.
@@ -293,7 +297,7 @@ object HBaseTableCatalog {
     val numReg = parameters.get(newTable).map(x => x.toInt).getOrElse(0)
     val rKey = RowKey(map.get(rowKey).get.asInstanceOf[String])
 
-    HBaseTableCatalog(nSpace, tName, rKey, SchemaMap(schemaMap), tCoder, coderSet, numReg)
+    HBaseTableCatalog(nSpace, tName, rKey, SchemaMap(schemaMap), tCoder, coderSet, numReg, maxVersions, latest)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
@@ -167,9 +167,7 @@ case class HBaseTableCatalog(
     sMap: SchemaMap,
     tCoder: String,
     coderSet: Set[String],
-    val numReg: Int,
-    maxVersions: Int,
-    latest: Boolean) extends Logging {
+    val numReg: Int) extends Logging {
   def toDataType = StructType(sMap.toFields)
   def getField(name: String) = sMap.getField(name)
   def getRowKey: Seq[Field] = row.fields
@@ -264,8 +262,6 @@ object HBaseTableCatalog {
     val tableMeta = map.get(table).get.asInstanceOf[Map[String, _]]
     val nSpace = tableMeta.get(nameSpace).getOrElse("default").asInstanceOf[String]
     val tName = tableMeta.get(tableName).get.asInstanceOf[String]
-    val maxVersions = parameters.get(HBaseRelation.MAX_VERSIONS).map(_.toInt).getOrElse(Int.MaxValue)
-    val latest = parameters.get(HBaseRelation.MARGE_TO_LATEST).map(_.toBoolean).getOrElse(true)
 
     // Since the catalog version 2.0, SHC supports Phoenix as coder.
     // If the catalog version specified by users is equal or later than 2.0, tableCoder must be specified.
@@ -297,7 +293,7 @@ object HBaseTableCatalog {
     val numReg = parameters.get(newTable).map(x => x.toInt).getOrElse(0)
     val rKey = RowKey(map.get(rowKey).get.asInstanceOf[String])
 
-    HBaseTableCatalog(nSpace, tName, rKey, SchemaMap(schemaMap), tCoder, coderSet, numReg, maxVersions, latest)
+    HBaseTableCatalog(nSpace, tName, rKey, SchemaMap(schemaMap), tCoder, coderSet, numReg)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -267,10 +267,9 @@ private[hbase] class HBaseTableScanRDD(
           val r = it.next()
           rows = buildRows(indexedFields, r)
           if(rows.isEmpty) {
-            // This is happened when it performed dataframe.count() (e.g. assert(twoVersions.count() == 3) in the test case).
-            // When performing users' queries, SHC gets the requiredColumns from Spark catalyst engine.
-            // However, when performing count() action, the requiredColumns given by Spark is empty (requiredColumns.length==0).
-            // Actually, that makes sense since what users want is the number of unique rows not the columns' values.
+            // If 'requiredColumns' is empty, 'indexedFields' will be empty, which leads to empty 'rows'.
+            // This happens when users' query doesn't require Spark/SHC to return any real data from HBase tables,
+            // e.g. dataframe.count()
             Row.fromSeq(Seq.empty)
           } else {
             nextRow()

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -231,6 +231,10 @@ private[hbase] class HBaseTableScanRDD(
     iterator
   }
 
+  /**
+    * Convert result in to list of rows aggregated by timestamp and flat this list into one iterator of rows
+    * This solution stand for fetching more than one version
+    */
   private def toFlattenRowIterator(
       it: Iterator[Result]): Iterator[Row] = {
 
@@ -263,7 +267,10 @@ private[hbase] class HBaseTableScanRDD(
           val r = it.next()
           rows = buildRows(indexedFields, r)
           if(rows.isEmpty) {
-            //why this happened?
+            // This is happened when it performed dataframe.count() (e.g. assert(twoVersions.count() == 3) in the test case).
+            // When performing users' queries, SHC gets the requiredColumns from Spark catalyst engine.
+            // However, when performing count() action, the requiredColumns given by Spark is empty (requiredColumns.length==0).
+            // Actually, that makes sense since what users want is the number of unique rows not the columns' values.
             Row.fromSeq(Seq.empty)
           } else {
             nextRow()

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -374,7 +374,7 @@ private[hbase] class HBaseTableScanRDD(
     } ++ gIt
 
     ShutdownHookManager.addShutdownHook { () => HBaseConnectionCache.close() }
-    if(relation.margeToLatest) {
+    if(relation.mergeToLatest) {
       toRowIterator(rIt)
     } else {
       toFlattenRowIterator(rIt)

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -294,7 +294,6 @@ private[hbase] class HBaseTableScanRDD(
         case _ => new Scan
       }
     }
-    scan.setMaxVersions(relation.catalog.maxVersions)
     handleTimeSemantics(scan)
 
     // set fetch size
@@ -327,7 +326,6 @@ private[hbase] class HBaseTableScanRDD(
             relation.catalog.shcTableCoder.toBytes(c.col))
         }
         filter.foreach(g.setFilter(_))
-        g.setMaxVersions(relation.catalog.maxVersions)
         gets.add(g)
       }
       val tmp = tbr.get(gets)
@@ -376,7 +374,7 @@ private[hbase] class HBaseTableScanRDD(
     } ++ gIt
 
     ShutdownHookManager.addShutdownHook { () => HBaseConnectionCache.close() }
-    if(relation.catalog.latest) {
+    if(relation.margeToLatest) {
       toRowIterator(rIt)
     } else {
       toFlattenRowIterator(rIt)

--- a/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
@@ -22,106 +22,82 @@ package org.apache.spark.sql
 
 import org.apache.spark.sql.execution.datasources.hbase.Logging
 import org.apache.spark.sql.execution.datasources.hbase.{HBaseRelation, HBaseTableCatalog}
-import org.apache.spark.sql.sources.PrunedFilteredScan
-
 
 class MaxVersionsSuite extends SHC with Logging {
 
-  def withCatalog(cat: String): DataFrame = {
-    sqlContext
-      .read
-      .options(Map(HBaseTableCatalog.tableCatalog->cat))
+  def withCatalog(cat: String, options: Map[String,String]): DataFrame = {
+    sqlContext.read
+      .options(options ++ Map(HBaseTableCatalog.tableCatalog -> catalog))
       .format("org.apache.spark.sql.execution.datasources.hbase")
       .load()
   }
 
-  private def prunedFilterScan(cat: String): PrunedFilteredScan = {
-    HBaseRelation(Map(HBaseTableCatalog.tableCatalog->cat),None)(sqlContext)
+  def persistDataInHBase(cat: String, data: Seq[HBaseRecord], timestamp: Long): Unit = {
+    val sql = sqlContext
+    import sql.implicits._
+    sc.parallelize(data).toDF.write
+      .options(Map(
+        HBaseTableCatalog.tableCatalog -> cat,
+        HBaseTableCatalog.newTable -> "5",
+        HBaseRelation.MAX_VERSIONS -> "3",
+        HBaseRelation.TIMESTAMP -> timestamp.toString
+      ))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .save()
   }
 
   test("Max Versions semantics") {
-    val sql = sqlContext
-    import sql.implicits._
 
     val oldestMs = 754869600000L
     val oldMs = 754869611111L
     val newMs = 754869622222L
     val newestMs = 754869633333L
 
-    val oldestData = (0 to 2).map { i =>
-      HBaseRecord(i, "ancient")
-    }
-    val oldData = (0 to 2).map { i =>
-      HBaseRecord(i, "old")
-    }
-    val newData = (0 to 2).map { i =>
-      HBaseRecord(i, "new")
-    }
-    val newestData = (0 to 1).map { i =>
-      HBaseRecord(i, "latest")
-    }
+    val oldestData = (0 to 2).map(HBaseRecord(_, "ancient"))
+    val oldData = (0 to 2).map(HBaseRecord(_, "old"))
+    val newData = (0 to 2).map(HBaseRecord(_, "new"))
+    val newestData = (0 to 1).map(HBaseRecord(_, "latest"))
 
-    sc.parallelize(oldestData).toDF.write.options(
-      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> oldestMs.toString))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .save()
-    sc.parallelize(oldData).toDF.write.options(
-      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> oldMs.toString))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .save()
-    sc.parallelize(newData).toDF.write.options(
-      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> newMs.toString))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .save()
-    sc.parallelize(newestData).toDF.write.options(
-      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> newestMs.toString))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .save()
+    persistDataInHBase(catalog, oldestData, oldestMs)
+    persistDataInHBase(catalog, oldData, oldMs)
+    persistDataInHBase(catalog, newData, newMs)
+    persistDataInHBase(catalog, newestData, newestMs)
 
     // Test specific last two versions
-    val twoVersions: DataFrame = sqlContext.read
-      .options(Map(HBaseTableCatalog.tableCatalog->catalog, HBaseRelation.MAX_VERSIONS -> "2", HBaseRelation.MERGE_TO_LATEST -> "false"))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .load()
+    val twoVersions: DataFrame = withCatalog(catalog, Map(
+      HBaseRelation.MAX_VERSIONS -> "2",
+      HBaseRelation.MERGE_TO_LATEST -> "false"
+    ))
 
     //count is made on HBase directly and return number of unique rows
     assert(twoVersions.count() == 3)
 
     val rows = twoVersions.take(10)
     assert(rows.size == 6)
-    assert(rows.filter(row => row.getString(7).contains("ancient")).size == 0)
-    assert(rows.filter(row => row.getString(7).contains("old")).size == 1)
-    assert(rows.filter(row => row.getString(7).contains("new")).size == 3)
-    assert(rows.filter(row => row.getString(7).contains("latest")).size == 2)
+    assert(rows.count(_.getString(7).contains("ancient")) == 0)
+    assert(rows.count(_.getString(7).contains("old")) == 1)
+    assert(rows.count(_.getString(7).contains("new")) == 3)
+    assert(rows.count(_.getString(7).contains("latest")) == 2)
 
     //we cannot take more then three because we create table with that size
-    val threeVersions: DataFrame = sqlContext.read
-      .options(Map(HBaseTableCatalog.tableCatalog->catalog, HBaseRelation.MAX_VERSIONS -> "4", HBaseRelation.MERGE_TO_LATEST -> "false"))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .load()
-
-    //count is made on HBase directly and return number of unique rows
-    assert(threeVersions.count() == 3)
+    val threeVersions: DataFrame = withCatalog(catalog, Map(
+      HBaseRelation.MAX_VERSIONS -> "4",
+      HBaseRelation.MERGE_TO_LATEST -> "false"
+    ))
 
     val threeRows = threeVersions.take(10)
     assert(threeRows.size == 9)
-    assert(threeRows.filter(row => row.getString(7).contains("ancient")).size == 1)
-    assert(threeRows.filter(row => row.getString(7).contains("old")).size == 3)
-    assert(threeRows.filter(row => row.getString(7).contains("new")).size == 3)
-    assert(threeRows.filter(row => row.getString(7).contains("latest")).size == 2)
+    assert(threeRows.count(_.getString(7).contains("ancient")) == 1)
+    assert(threeRows.count(_.getString(7).contains("old")) == 3)
+    assert(threeRows.count(_.getString(7).contains("new")) == 3)
+    assert(threeRows.count(_.getString(7).contains("latest")) == 2)
 
     // Test specific only last versions
-    val lastVersions: DataFrame = sqlContext.read
-      .options(Map(HBaseTableCatalog.tableCatalog->catalog))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .load()
+    val lastVersions: DataFrame = withCatalog(catalog, Map.empty)
 
     val lastRows = lastVersions.take(10)
     assert(lastRows.size == 3)
-    assert(lastRows.filter(row => row.getString(7).contains("new")).size == 1)
-    assert(lastRows.filter(row => row.getString(7).contains("latest")).size == 2)
-
-
+    assert(lastRows.count(_.getString(7).contains("new")) == 1)
+    assert(lastRows.count(_.getString(7).contains("latest")) == 2)
   }
-
 }

--- a/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * File modified by Hortonworks, Inc. Modifications are also licensed under
+ * the Apache Software License, Version 2.0.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.execution.datasources.hbase.Logging
+import org.apache.spark.sql.execution.datasources.hbase.{HBaseRelation, HBaseTableCatalog}
+import org.apache.spark.sql.sources.PrunedFilteredScan
+
+
+class MaxVersionsSuite extends SHC with Logging {
+
+  def withCatalog(cat: String): DataFrame = {
+    sqlContext
+      .read
+      .options(Map(HBaseTableCatalog.tableCatalog->cat))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .load()
+  }
+
+  private def prunedFilterScan(cat: String): PrunedFilteredScan = {
+    HBaseRelation(Map(HBaseTableCatalog.tableCatalog->cat),None)(sqlContext)
+  }
+
+  test("Max Versions semantics") {
+    val sql = sqlContext
+    import sql.implicits._
+
+    val oldestMs = 754869600000L
+    val oldMs = 754869611111L
+    val newMs = 754869622222L
+    val newestMs = 754869633333L
+
+    val oldestData = (0 to 2).map { i =>
+      HBaseRecord(i, "ancient")
+    }
+    val oldData = (0 to 2).map { i =>
+      HBaseRecord(i, "old")
+    }
+    val newData = (0 to 2).map { i =>
+      HBaseRecord(i, "new")
+    }
+    val newestData = (0 to 1).map { i =>
+      HBaseRecord(i, "latest")
+    }
+
+    sc.parallelize(oldestData).toDF.write.options(
+      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> oldestMs.toString))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .save()
+    sc.parallelize(oldData).toDF.write.options(
+      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> oldMs.toString))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .save()
+    sc.parallelize(newData).toDF.write.options(
+      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> newMs.toString))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .save()
+    sc.parallelize(newestData).toDF.write.options(
+      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> newestMs.toString))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .save()
+
+    // Test specific last two versions
+    val twoVersions: DataFrame = sqlContext.read
+      .options(Map(HBaseTableCatalog.tableCatalog->catalog, HBaseRelation.MAX_VERSIONS -> "2", HBaseRelation.MARGE_TO_LATEST -> "false"))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .load()
+
+    //count is made on HBase directly and return number of unique rows
+    assert(twoVersions.count() == 3)
+
+    val rows = twoVersions.take(10)
+    assert(rows.size == 6)
+    assert(rows.filter(row => row.getString(7).contains("ancient")).size == 0)
+    assert(rows.filter(row => row.getString(7).contains("old")).size == 1)
+    assert(rows.filter(row => row.getString(7).contains("new")).size == 3)
+    assert(rows.filter(row => row.getString(7).contains("latest")).size == 2)
+
+    //we cannot take more then three because we create table with that size
+    val threeVersions: DataFrame = sqlContext.read
+      .options(Map(HBaseTableCatalog.tableCatalog->catalog, HBaseRelation.MAX_VERSIONS -> "4", HBaseRelation.MARGE_TO_LATEST -> "false"))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .load()
+
+    //count is made on HBase directly and return number of unique rows
+    assert(threeVersions.count() == 3)
+
+    val threeRows = threeVersions.take(10)
+    assert(threeRows.size == 9)
+    assert(threeRows.filter(row => row.getString(7).contains("ancient")).size == 1)
+    assert(threeRows.filter(row => row.getString(7).contains("old")).size == 3)
+    assert(threeRows.filter(row => row.getString(7).contains("new")).size == 3)
+    assert(threeRows.filter(row => row.getString(7).contains("latest")).size == 2)
+
+    // Test specific only last versions
+    val lastVersions: DataFrame = sqlContext.read
+      .options(Map(HBaseTableCatalog.tableCatalog->catalog))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .load()
+
+    val lastRows = lastVersions.take(10)
+    assert(lastRows.size == 3)
+    assert(lastRows.filter(row => row.getString(7).contains("new")).size == 1)
+    assert(lastRows.filter(row => row.getString(7).contains("latest")).size == 2)
+
+
+  }
+
+}

--- a/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
@@ -1,8 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (C) 2017 Hortonworks, Inc. All rights reserved. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. This file is licensed to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
@@ -13,9 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * File modified by Hortonworks, Inc. Modifications are also licensed under
- * the Apache Software License, Version 2.0.
  */
 
 package org.apache.spark.sql

--- a/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
@@ -80,7 +80,7 @@ class MaxVersionsSuite extends SHC with Logging {
 
     // Test specific last two versions
     val twoVersions: DataFrame = sqlContext.read
-      .options(Map(HBaseTableCatalog.tableCatalog->catalog, HBaseRelation.MAX_VERSIONS -> "2", HBaseRelation.MARGE_TO_LATEST -> "false"))
+      .options(Map(HBaseTableCatalog.tableCatalog->catalog, HBaseRelation.MAX_VERSIONS -> "2", HBaseRelation.MERGE_TO_LATEST -> "false"))
       .format("org.apache.spark.sql.execution.datasources.hbase")
       .load()
 
@@ -96,7 +96,7 @@ class MaxVersionsSuite extends SHC with Logging {
 
     //we cannot take more then three because we create table with that size
     val threeVersions: DataFrame = sqlContext.read
-      .options(Map(HBaseTableCatalog.tableCatalog->catalog, HBaseRelation.MAX_VERSIONS -> "4", HBaseRelation.MARGE_TO_LATEST -> "false"))
+      .options(Map(HBaseTableCatalog.tableCatalog->catalog, HBaseRelation.MAX_VERSIONS -> "4", HBaseRelation.MERGE_TO_LATEST -> "false"))
       .format("org.apache.spark.sql.execution.datasources.hbase")
       .load()
 


### PR DESCRIPTION
Hi Guys, 
I'm not sure this is a correct way to do that but we need such feature. I'm open to any suggestion and collaborate on this feature and project.

I hope this will be a good start point to a discussion on this feature.

## What changes were proposed in this pull request?

* fix MAX_VERSIONS flag usage (it was not used)
* give the ability to create table which holds more than one version
* give the ability to fetch more than one (latest) view of the same entity
* you can set number of versions to fetch

## How was this patch tested?

It contains own suite with few integration tests.