### PR TITLE
add support for multiple versions

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
@@ -80,6 +80,7 @@ case class HBaseRelation(
   val minStamp = parameters.get(HBaseRelation.MIN_STAMP).map(_.toLong)
   val maxStamp = parameters.get(HBaseRelation.MAX_STAMP).map(_.toLong)
   val maxVersions = parameters.get(HBaseRelation.MAX_VERSIONS).map(_.toInt)
+  val mergeToLatest = parameters.get(HBaseRelation.MERGE_TO_LATEST).map(_.toBoolean).getOrElse(true)
 
   val catalog = HBaseTableCatalog(parameters)
 
@@ -148,6 +149,7 @@ case class HBaseRelation(
         cfs.foreach { x =>
          val cf = new HColumnDescriptor(x.getBytes())
           logDebug(s"add family $x to ${catalog.name}")
+          maxVersions.foreach(cf.setMaxVersions(_))
           tableDesc.addFamily(cf)
         }
 
@@ -311,6 +313,7 @@ object HBaseRelation {
   val MIN_STAMP = "minStamp"
   val MAX_STAMP = "maxStamp"
   val MAX_VERSIONS = "maxVersions"
+  val MERGE_TO_LATEST = "mergeToLatest"
   val HBASE_CONFIGURATION = "hbaseConfiguration"
   // HBase configuration file such as HBase-site.xml, core-site.xml
   val HBASE_CONFIGFILE = "hbaseConfigFile"

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -143,11 +143,11 @@ private[hbase] class HBaseTableScanRDD(
     }
 
     val ts = valueSeq.foldLeft(Set.empty[Long])((acc, map) => acc ++ map.keySet)
-    //we are loosing duplicate here, because we didn't support passing version (timestamp) to the row
+    // we are loosing duplicate here, because we didn't support passing version (timestamp) to the row
     ts.map(version => {
       keySeq ++ valueSeq.map(_.apply(version)).toMap
     }).map { unioned =>
-      // Return the row ordered by the requested order
+      // return the row ordered by the requested order
       Row.fromSeq(fields.map(unioned.get(_).getOrElse(null)))
     }
   }
@@ -232,9 +232,9 @@ private[hbase] class HBaseTableScanRDD(
   }
 
   /**
-    * Convert result in to list of rows aggregated by timestamp and flat this list into one iterator of rows
-    * This solution stand for fetching more than one version
-    */
+   * Convert result in to list of rows aggregated by timestamp and flat this list into one iterator of rows
+   * This solution stand for fetching more than one version
+   */
   private def toFlattenRowIterator(
       it: Iterator[Result]): Iterator[Row] = {
 
@@ -269,7 +269,7 @@ private[hbase] class HBaseTableScanRDD(
           if(rows.isEmpty) { 
             // If 'requiredColumns' is empty, 'indexedFields' will be empty, which leads to empty 'rows'.
             // This happens when users' query doesn't require Spark/SHC to return any real data from HBase tables,
-            // e.g. dataframe.count().
+            // e.g. dataframe.count()
             Row.fromSeq(Seq.empty)
           } else {
             nextRow()

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -267,7 +267,10 @@ private[hbase] class HBaseTableScanRDD(
           val r = it.next()
           rows = buildRows(indexedFields, r)
           if(rows.isEmpty) {
-            //why this happened?
+            // This is happened when it performed dataframe.count() (e.g. assert(twoVersions.count() == 3) in the test case).
+            // When performing users' queries, SHC gets the requiredColumns from Spark catalyst engine.
+            // However, when performing count() action, the requiredColumns given by Spark is empty (requiredColumns.length==0).
+            // Actually, that makes sense since what users want is the number of unique rows not the columns' values.
             Row.fromSeq(Seq.empty)
           } else {
             nextRow()

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -231,6 +231,10 @@ private[hbase] class HBaseTableScanRDD(
     iterator
   }
 
+  /**
+    * Convert result in to list of rows aggregated by timestamp and flat this list into one iterator of rows
+    * This solution stand for fetching more than one version
+    */
   private def toFlattenRowIterator(
       it: Iterator[Result]): Iterator[Row] = {
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -268,7 +268,7 @@ private[hbase] class HBaseTableScanRDD(
           rows = buildRows(indexedFields, r)
           if(rows.isEmpty) { 
             // If 'requiredColumns' is empty, 'indexedFields' will be empty, which leads to empty 'rows'.
-            // This happens when users' query doesn't require Spark/SHC to return any real data from HBase tables,
+            // This happens when users' query doesn't require Spark/SHC to return any real data from HBase tables,
             // e.g. dataframe.count()
             Row.fromSeq(Seq.empty)
           } else {

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -266,11 +266,10 @@ private[hbase] class HBaseTableScanRDD(
         if(rows.isEmpty) {
           val r = it.next()
           rows = buildRows(indexedFields, r)
-          if(rows.isEmpty) {
-            // This is happened when it performed dataframe.count() (e.g. assert(twoVersions.count() == 3) in the test case).
-            // When performing users' queries, SHC gets the requiredColumns from Spark catalyst engine.
-            // However, when performing count() action, the requiredColumns given by Spark is empty (requiredColumns.length==0).
-            // Actually, that makes sense since what users want is the number of unique rows not the columns' values.
+          if(rows.isEmpty) { 
+            // If 'requiredColumns' is empty, 'indexedFields' will be empty, which leads to empty 'rows'.
+            // This happens when users' query doesn't require Spark/SHC to return any real data from HBase tables,
+            // e.g. dataframe.count().
             Row.fromSeq(Seq.empty)
           } else {
             nextRow()

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -116,6 +116,42 @@ private[hbase] class HBaseTableScanRDD(
     Row.fromSeq(fields.map(unioned.get(_).getOrElse(null)))
   }
 
+  // TODO: It is a big performance overhead, as for each row, there is a hashmap lookup.
+  def buildRows(fields: Seq[Field], result: Result): Set[Row] = {
+    val r = result.getRow
+    val keySeq: Map[Field, Any] = {
+      if (relation.isComposite()) {
+        relation.catalog.shcTableCoder
+          .decodeCompositeRowKey(r, relation.catalog.getRowKey)
+      } else {
+        val f = relation.catalog.getRowKey.head
+        Seq((f, SHCDataTypeFactory.create(f).fromBytes(r))).toMap
+      }
+    }
+
+    val valueSeq: Seq[Map[Long, (Field, Any)]] = fields.filter(!_.isRowKey).map { x =>
+      import scala.collection.JavaConverters.asScalaBufferConverter
+      val dataType = SHCDataTypeFactory.create(x)
+      val kvs = result.getColumnCells(
+        relation.catalog.shcTableCoder.toBytes(x.cf),
+        relation.catalog.shcTableCoder.toBytes(x.col)).asScala
+
+      kvs.map(kv => {
+        val v = CellUtil.cloneValue(kv)
+        (kv.getTimestamp, x -> dataType.fromBytes(v))
+      }).toMap.withDefaultValue(x -> null)
+    }
+
+    val ts = valueSeq.foldLeft(Set.empty[Long])((acc, map) => acc ++ map.keySet)
+    //we are loosing duplicate here, because we didn't support passing version (timestamp) to the row
+    ts.map(version => {
+      keySeq ++ valueSeq.map(_.apply(version)).toMap
+    }).map { unioned =>
+      // Return the row ordered by the requested order
+      Row.fromSeq(fields.map(unioned.get(_).getOrElse(null)))
+    }
+  }
+
   private def toResultIterator(result: GetResource): Iterator[Result] = {
     val iterator = new Iterator[Result] {
       var idx = 0
@@ -190,6 +226,51 @@ private[hbase] class HBaseTableScanRDD(
         rowCount += 1
         val r = it.next()
         buildRow(indexedFields, r)
+      }
+    }
+    iterator
+  }
+
+  private def toFlattenRowIterator(
+      it: Iterator[Result]): Iterator[Row] = {
+
+    val iterator = new Iterator[Row] {
+      val start = System.currentTimeMillis()
+      var rowCount: Int = 0
+      var rows: Set[Row] = Set.empty[Row]
+      val indexedFields = relation.getIndexedProjections(requiredColumns).map(_._1)
+
+      override def hasNext: Boolean = {
+        if(!rows.isEmpty || it.hasNext) {
+          true
+        }
+        else {
+          val end = System.currentTimeMillis()
+          logInfo(s"returned ${rowCount} rows from hbase in ${end - start} ms")
+          false
+        }
+      }
+
+      private def nextRow(): Row = {
+        val row = rows.head
+        rows = rows.tail
+        row
+      }
+
+      override def next(): Row = {
+        rowCount += 1
+        if(rows.isEmpty) {
+          val r = it.next()
+          rows = buildRows(indexedFields, r)
+          if(rows.isEmpty) {
+            //why this happened?
+            Row.fromSeq(Seq.empty)
+          } else {
+            nextRow()
+          }
+        } else {
+          nextRow()
+        }
       }
     }
     iterator
@@ -293,7 +374,11 @@ private[hbase] class HBaseTableScanRDD(
     } ++ gIt
 
     ShutdownHookManager.addShutdownHook { () => HBaseConnectionCache.close() }
-    toRowIterator(rIt)
+    if(relation.mergeToLatest) {
+      toRowIterator(rIt)
+    } else {
+      toFlattenRowIterator(rIt)
+    }
   }
 
   private def handleTimeSemantics(query: Query): Unit = {

--- a/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * File modified by Hortonworks, Inc. Modifications are also licensed under
+ * the Apache Software License, Version 2.0.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.Logging
+import org.apache.spark.sql.execution.datasources.hbase.{HBaseRelation, HBaseTableCatalog}
+import org.apache.spark.sql.sources.PrunedFilteredScan
+
+
+class MaxVersionsSuite extends SHC with Logging {
+
+  def withCatalog(cat: String): DataFrame = {
+    sqlContext
+      .read
+      .options(Map(HBaseTableCatalog.tableCatalog->cat))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .load()
+  }
+
+  private def prunedFilterScan(cat: String): PrunedFilteredScan = {
+    HBaseRelation(Map(HBaseTableCatalog.tableCatalog->cat),None)(sqlContext)
+  }
+
+  test("Max Versions semantics") {
+    val sql = sqlContext
+    import sql.implicits._
+
+    val oldestMs = 754869600000L
+    val oldMs = 754869611111L
+    val newMs = 754869622222L
+    val newestMs = 754869633333L
+
+    val oldestData = (0 to 2).map { i =>
+      HBaseRecord(i, "ancient")
+    }
+    val oldData = (0 to 2).map { i =>
+      HBaseRecord(i, "old")
+    }
+    val newData = (0 to 2).map { i =>
+      HBaseRecord(i, "new")
+    }
+    val newestData = (0 to 1).map { i =>
+      HBaseRecord(i, "latest")
+    }
+
+    sc.parallelize(oldestData).toDF.write.options(
+      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> oldestMs.toString))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .save()
+    sc.parallelize(oldData).toDF.write.options(
+      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> oldMs.toString))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .save()
+    sc.parallelize(newData).toDF.write.options(
+      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> newMs.toString))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .save()
+    sc.parallelize(newestData).toDF.write.options(
+      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> newestMs.toString))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .save()
+
+    // Test specific last two versions
+    val twoVersions: DataFrame = sqlContext.read
+      .options(Map(HBaseTableCatalog.tableCatalog->catalog, HBaseRelation.MAX_VERSIONS -> "2", HBaseRelation.MERGE_TO_LATEST -> "false"))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .load()
+
+    //count is made on HBase directly and return number of unique rows
+    assert(twoVersions.count() == 3)
+
+    val rows = twoVersions.take(10)
+    assert(rows.size == 6)
+    assert(rows.filter(row => row.getString(7).contains("ancient")).size == 0)
+    assert(rows.filter(row => row.getString(7).contains("old")).size == 1)
+    assert(rows.filter(row => row.getString(7).contains("new")).size == 3)
+    assert(rows.filter(row => row.getString(7).contains("latest")).size == 2)
+
+    //we cannot take more then three because we create table with that size
+    val threeVersions: DataFrame = sqlContext.read
+      .options(Map(HBaseTableCatalog.tableCatalog->catalog, HBaseRelation.MAX_VERSIONS -> "4", HBaseRelation.MERGE_TO_LATEST -> "false"))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .load()
+
+    //count is made on HBase directly and return number of unique rows
+    assert(threeVersions.count() == 3)
+
+    val threeRows = threeVersions.take(10)
+    assert(threeRows.size == 9)
+    assert(threeRows.filter(row => row.getString(7).contains("ancient")).size == 1)
+    assert(threeRows.filter(row => row.getString(7).contains("old")).size == 3)
+    assert(threeRows.filter(row => row.getString(7).contains("new")).size == 3)
+    assert(threeRows.filter(row => row.getString(7).contains("latest")).size == 2)
+
+    // Test specific only last versions
+    val lastVersions: DataFrame = sqlContext.read
+      .options(Map(HBaseTableCatalog.tableCatalog->catalog))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .load()
+
+    val lastRows = lastVersions.take(10)
+    assert(lastRows.size == 3)
+    assert(lastRows.filter(row => row.getString(7).contains("new")).size == 1)
+    assert(lastRows.filter(row => row.getString(7).contains("latest")).size == 2)
+
+
+  }
+
+}

--- a/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
@@ -26,8 +26,6 @@ import org.apache.spark.sql.execution.datasources.hbase.{HBaseRelation, HBaseTab
 
 class MaxVersionsSuite extends SHC with Logging {
 
-  val sql = sqlContext
-  import sql.implicits._
 
   def withCatalog(cat: String, options: Map[String,String]): DataFrame = {
     sqlContext.read
@@ -37,6 +35,8 @@ class MaxVersionsSuite extends SHC with Logging {
   }
 
   def persistDataInHBase(cat: String, data: Seq[HBaseRecord], timestamp: Long): Unit = {
+    val sql = sqlContext
+    import sql.implicits._
     sc.parallelize(data).toDF.write
       .options(Map(
         HBaseTableCatalog.tableCatalog -> cat,

--- a/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
@@ -27,60 +27,45 @@ import org.apache.spark.sql.sources.PrunedFilteredScan
 
 class MaxVersionsSuite extends SHC with Logging {
 
-  def withCatalog(cat: String): DataFrame = {
-    sqlContext
-      .read
-      .options(Map(HBaseTableCatalog.tableCatalog->cat))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .load()
-  }
+  val sql = sqlContext
+  import sql.implicits._
 
-  private def prunedFilterScan(cat: String): PrunedFilteredScan = {
-    HBaseRelation(Map(HBaseTableCatalog.tableCatalog->cat),None)(sqlContext)
+  def persistDataInHBase(cat: String, data: Seq[HBaseRecord], timestamp: Long): Unit = {
+    sc.parallelize(data).toDF.write
+      .options(Map(
+        HBaseTableCatalog.tableCatalog -> cat,
+        HBaseTableCatalog.newTable -> "5",
+        HBaseRelation.MAX_VERSIONS -> "3",
+        HBaseRelation.TIMESTAMP -> timestamp.toString
+      ))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .save()
   }
 
   test("Max Versions semantics") {
-    val sql = sqlContext
-    import sql.implicits._
 
     val oldestMs = 754869600000L
     val oldMs = 754869611111L
     val newMs = 754869622222L
     val newestMs = 754869633333L
 
-    val oldestData = (0 to 2).map { i =>
-      HBaseRecord(i, "ancient")
-    }
-    val oldData = (0 to 2).map { i =>
-      HBaseRecord(i, "old")
-    }
-    val newData = (0 to 2).map { i =>
-      HBaseRecord(i, "new")
-    }
-    val newestData = (0 to 1).map { i =>
-      HBaseRecord(i, "latest")
-    }
+    val oldestData = (0 to 2).map(HBaseRecord(_, "ancient"))
+    val oldData = (0 to 2).map(HBaseRecord(_, "old"))
+    val newData = (0 to 2).map(HBaseRecord(_, "new"))
+    val newestData = (0 to 1).map(HBaseRecord(_, "latest"))
 
-    sc.parallelize(oldestData).toDF.write.options(
-      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> oldestMs.toString))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .save()
-    sc.parallelize(oldData).toDF.write.options(
-      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> oldMs.toString))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .save()
-    sc.parallelize(newData).toDF.write.options(
-      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> newMs.toString))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .save()
-    sc.parallelize(newestData).toDF.write.options(
-      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5", HBaseRelation.MAX_VERSIONS -> "3", HBaseRelation.TIMESTAMP -> newestMs.toString))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .save()
+    persistDataInHBase(catalog, oldestData, oldestMs)
+    persistDataInHBase(catalog, oldData, oldMs)
+    persistDataInHBase(catalog, newData, newMs)
+    persistDataInHBase(catalog, newestData, newestMs)
 
     // Test specific last two versions
     val twoVersions: DataFrame = sqlContext.read
-      .options(Map(HBaseTableCatalog.tableCatalog->catalog, HBaseRelation.MAX_VERSIONS -> "2", HBaseRelation.MERGE_TO_LATEST -> "false"))
+      .options(Map(
+        HBaseTableCatalog.tableCatalog->catalog,
+        HBaseRelation.MAX_VERSIONS -> "2",
+        HBaseRelation.MERGE_TO_LATEST -> "false"
+      ))
       .format("org.apache.spark.sql.execution.datasources.hbase")
       .load()
 
@@ -89,37 +74,40 @@ class MaxVersionsSuite extends SHC with Logging {
 
     val rows = twoVersions.take(10)
     assert(rows.size == 6)
-    assert(rows.filter(row => row.getString(7).contains("ancient")).size == 0)
-    assert(rows.filter(row => row.getString(7).contains("old")).size == 1)
-    assert(rows.filter(row => row.getString(7).contains("new")).size == 3)
-    assert(rows.filter(row => row.getString(7).contains("latest")).size == 2)
+    assert(rows.count(_.getString(7).contains("ancient")) == 0)
+    assert(rows.count(_.getString(7).contains("old")) == 1)
+    assert(rows.count(_.getString(7).contains("new")) == 3)
+    assert(rows.count(_.getString(7).contains("latest")) == 2)
 
     //we cannot take more then three because we create table with that size
     val threeVersions: DataFrame = sqlContext.read
-      .options(Map(HBaseTableCatalog.tableCatalog->catalog, HBaseRelation.MAX_VERSIONS -> "4", HBaseRelation.MERGE_TO_LATEST -> "false"))
+      .options(Map(
+        HBaseTableCatalog.tableCatalog->catalog,
+        HBaseRelation.MAX_VERSIONS -> "4",
+        HBaseRelation.MERGE_TO_LATEST -> "false"
+      ))
       .format("org.apache.spark.sql.execution.datasources.hbase")
       .load()
 
-    //count is made on HBase directly and return number of unique rows
-    assert(threeVersions.count() == 3)
-
     val threeRows = threeVersions.take(10)
     assert(threeRows.size == 9)
-    assert(threeRows.filter(row => row.getString(7).contains("ancient")).size == 1)
-    assert(threeRows.filter(row => row.getString(7).contains("old")).size == 3)
-    assert(threeRows.filter(row => row.getString(7).contains("new")).size == 3)
-    assert(threeRows.filter(row => row.getString(7).contains("latest")).size == 2)
+    assert(threeRows.count(_.getString(7).contains("ancient")) == 1)
+    assert(threeRows.count(_.getString(7).contains("old")) == 3)
+    assert(threeRows.count(_.getString(7).contains("new")) == 3)
+    assert(threeRows.count(_.getString(7).contains("latest")) == 2)
 
     // Test specific only last versions
     val lastVersions: DataFrame = sqlContext.read
-      .options(Map(HBaseTableCatalog.tableCatalog->catalog))
+      .options(Map(
+        HBaseTableCatalog.tableCatalog->catalog
+      ))
       .format("org.apache.spark.sql.execution.datasources.hbase")
       .load()
 
     val lastRows = lastVersions.take(10)
     assert(lastRows.size == 3)
-    assert(lastRows.filter(row => row.getString(7).contains("new")).size == 1)
-    assert(lastRows.filter(row => row.getString(7).contains("latest")).size == 2)
+    assert(lastRows.count(_.getString(7).contains("new")) == 1)
+    assert(lastRows.count(_.getString(7).contains("latest")) == 2)
 
 
   }

--- a/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
@@ -23,9 +23,7 @@ package org.apache.spark.sql
 import org.apache.spark.Logging
 import org.apache.spark.sql.execution.datasources.hbase.{HBaseRelation, HBaseTableCatalog}
 
-
 class MaxVersionsSuite extends SHC with Logging {
-
 
   def withCatalog(cat: String, options: Map[String,String]): DataFrame = {
     sqlContext.read
@@ -101,8 +99,5 @@ class MaxVersionsSuite extends SHC with Logging {
     assert(lastRows.size == 3)
     assert(lastRows.count(_.getString(7).contains("new")) == 1)
     assert(lastRows.count(_.getString(7).contains("latest")) == 2)
-
-
   }
-
 }

--- a/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/MaxVersionsSuite.scala
@@ -22,13 +22,19 @@ package org.apache.spark.sql
 
 import org.apache.spark.Logging
 import org.apache.spark.sql.execution.datasources.hbase.{HBaseRelation, HBaseTableCatalog}
-import org.apache.spark.sql.sources.PrunedFilteredScan
 
 
 class MaxVersionsSuite extends SHC with Logging {
 
   val sql = sqlContext
   import sql.implicits._
+
+  def withCatalog(cat: String, options: Map[String,String]): DataFrame = {
+    sqlContext.read
+      .options(options ++ Map(HBaseTableCatalog.tableCatalog -> catalog))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .load()
+  }
 
   def persistDataInHBase(cat: String, data: Seq[HBaseRecord], timestamp: Long): Unit = {
     sc.parallelize(data).toDF.write
@@ -60,14 +66,10 @@ class MaxVersionsSuite extends SHC with Logging {
     persistDataInHBase(catalog, newestData, newestMs)
 
     // Test specific last two versions
-    val twoVersions: DataFrame = sqlContext.read
-      .options(Map(
-        HBaseTableCatalog.tableCatalog->catalog,
+    val twoVersions: DataFrame = withCatalog(catalog, Map(
         HBaseRelation.MAX_VERSIONS -> "2",
         HBaseRelation.MERGE_TO_LATEST -> "false"
       ))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .load()
 
     //count is made on HBase directly and return number of unique rows
     assert(twoVersions.count() == 3)
@@ -80,14 +82,10 @@ class MaxVersionsSuite extends SHC with Logging {
     assert(rows.count(_.getString(7).contains("latest")) == 2)
 
     //we cannot take more then three because we create table with that size
-    val threeVersions: DataFrame = sqlContext.read
-      .options(Map(
-        HBaseTableCatalog.tableCatalog->catalog,
+    val threeVersions: DataFrame = withCatalog(catalog, Map(
         HBaseRelation.MAX_VERSIONS -> "4",
         HBaseRelation.MERGE_TO_LATEST -> "false"
       ))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .load()
 
     val threeRows = threeVersions.take(10)
     assert(threeRows.size == 9)
@@ -97,12 +95,7 @@ class MaxVersionsSuite extends SHC with Logging {
     assert(threeRows.count(_.getString(7).contains("latest")) == 2)
 
     // Test specific only last versions
-    val lastVersions: DataFrame = sqlContext.read
-      .options(Map(
-        HBaseTableCatalog.tableCatalog->catalog
-      ))
-      .format("org.apache.spark.sql.execution.datasources.hbase")
-      .load()
+    val lastVersions: DataFrame = withCatalog(catalog, Map.empty)
 
     val lastRows = lastVersions.take(10)
     assert(lastRows.size == 3)


### PR DESCRIPTION
## What changes were proposed in this pull request?

* extend MAX_VERSIONS flag usage (it was used to set how many versions was fetched only)
* give the ability to create table which holds more than one version
* give the ability to fetch more than one (latest) view of the same entity
* you can set number of versions to fetch

## How was this patch tested?

It contains own suite with few integration tests.
