### PR TITLE
[SHC-233] Use Apache Spark 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   </distributionManagement>   
 
   <properties>
-    <spark.version>2.3.1-SNAPSHOT</spark.version>
+    <spark.version>2.3.0</spark.version>
     <hbase.version>1.1.2</hbase.version>
     <phoenix.version>4.9.0-HBase-1.1</phoenix.version>
     <test_classpath_file>${project.build.directory}/spark-test-classpath.txt</test_classpath_file>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since Apache Spark 2.3.0 is officially released, we had better use it.

## How was this patch tested?

Pass the Travis CI.