### PR TITLE
Patch field order with avro

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
@@ -95,7 +95,7 @@ case class Field(
 
   // converter from catalyst to avro
   lazy val catalystToAvro: (Any) => Any ={
-    SchemaConverters.createConverterToAvro(dt, colName, "recordNamespace")
+    SchemaConverters.createConverterToAvro(dt, exeSchema.get,colName, "recordNamespace")
   }
 
   val dt =

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
@@ -244,7 +244,7 @@ object SchemaConverters {
   def createConverterToAvro(
       dataType: DataType,
       avroType: Schema,
-      structName: String,
+      currentFieldName: String,
       recordNamespace: String): (Any) => Any = {
 
     dataType match {
@@ -258,8 +258,11 @@ object SchemaConverters {
       case TimestampType => (item: Any) =>
         if (item == null) null else item.asInstanceOf[Timestamp].getTime
       case ArrayType(elementType, _) =>
-        val fieldname = dataType.asInstanceOf[StructType].fieldNames(0)
-        val elementConverter = createConverterToAvro(elementType,avroType.getField(fieldname).schema().getElementType, structName, recordNamespace)
+        val elementConverter = createConverterToAvro(
+          elementType,
+          avroType.getField(currentFieldName).schema().getElementType, 
+          avroType.getField(currentFieldName).schema().getElementType.getName, 
+          recordNamespace)
         (item: Any) => {
           if (item == null) {
             null
@@ -276,8 +279,11 @@ object SchemaConverters {
           }
         }
       case MapType(StringType, valueType, _) =>
-        val fieldname = dataType.asInstanceOf[StructType].fieldNames(0)
-        val valueConverter = createConverterToAvro(valueType,avroType.getField(fieldname).schema().getValueType, structName, recordNamespace)
+        val valueConverter = createConverterToAvro(
+          valueType,
+          avroType.getField(fieldname).schema().getValueType,
+          avroType.getField(fieldname).schema().getValueType.getName, 
+          recordNamespace)
         (item: Any) => {
           if (item == null) {
             null

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
@@ -302,19 +302,23 @@ object SchemaConverters {
         val fieldConverters = structType.fields.map(field =>
           createConverterToAvro(
             field.dataType,
-            avroType.getField(field.name).schema(),
+            schema.getField(field.name).schema(),
             field.name,
             recordNamespace))
         (item: Any) => {
           if (item == null) {
             null
           } else {
-            println(s"SEB, item: $item")
+            // TODO: I don't understand yet why ... Not sure it's because this PR
+            var data = item
+            if (item.isInstanceOf[Seq]) 
+              data = item(0)
+            println(s"SEB, item: $data")
             val record = new Record(schema)
             val convertersIterator = fieldConverters.iterator
             val fieldNamesIterator = dataType.asInstanceOf[StructType].fieldNames.iterator
             // val row = item.asInstanceOf[Row]
-            val rowIterator = item.asInstanceOf[Row].toSeq.iterator
+            val rowIterator = data.asInstanceOf[Row].toSeq.iterator
 
             // Parse in the dataset order
             while (convertersIterator.hasNext) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
@@ -309,7 +309,6 @@ object SchemaConverters {
           if (item == null) {
             null
           } else {
-            println(s"SEB, item: $item")
             val record = new Record(schema)
             val convertersIterator = fieldConverters.iterator
             val fieldNamesIterator = dataType.asInstanceOf[StructType].fieldNames.iterator

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
@@ -260,8 +260,8 @@ object SchemaConverters {
       case ArrayType(elementType, _) =>
         val elementConverter = createConverterToAvro(
           elementType,
-          avroType.getField(currentFieldName).schema().getElementType, 
-          avroType.getField(currentFieldName).schema().getElementType.getName, 
+          avroType.getElementType, 
+          avroType.getElementType.getName, 
           recordNamespace)
         (item: Any) => {
           if (item == null) {
@@ -281,8 +281,8 @@ object SchemaConverters {
       case MapType(StringType, valueType, _) =>
         val valueConverter = createConverterToAvro(
           valueType,
-          avroType.getField(currentFieldName).schema().getValueType,
-          avroType.getField(currentFieldName).schema().getValueType.getName, 
+          avroType.getValueType,
+          avroType.getValueType.getName, 
           recordNamespace)
         (item: Any) => {
           if (item == null) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
@@ -258,7 +258,7 @@ object SchemaConverters {
       case TimestampType => (item: Any) =>
         if (item == null) null else item.asInstanceOf[Timestamp].getTime
       case ArrayType(elementType, _) =>
-        val elementConverter = createConverterToAvro(elementType,avroType.getField(structName).schema(), structName, recordNamespace)
+        val elementConverter = createConverterToAvro(elementType,avroType.getField(structName).schema().getElementType, structName, recordNamespace)
         (item: Any) => {
           if (item == null) {
             null
@@ -275,7 +275,7 @@ object SchemaConverters {
           }
         }
       case MapType(StringType, valueType, _) =>
-        val valueConverter = createConverterToAvro(valueType,avroType.getField(structName).schema(), structName, recordNamespace)
+        val valueConverter = createConverterToAvro(valueType,avroType.getField(structName).schema().getElementType, structName, recordNamespace)
         (item: Any) => {
           if (item == null) {
             null

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
@@ -55,7 +55,7 @@ class Avro(f:Option[Field] = None) extends SHCDataType {
   def toBytes(input: Any): Array[Byte] = {
     // Here we assume the top level type is structType
     if (f.isDefined) {
-      val record = f.get.catalystToAvro(input,f.get.exeSchema.get)
+      val record = f.get.catalystToAvro(input)
       AvroSerde.serialize(record, f.get.exeSchema.get) 
     } else {
       throw new UnsupportedOperationException(
@@ -306,25 +306,15 @@ object SchemaConverters {
             field.name,
             recordNamespace))
         (item: Any) => {
-          if (item == null) {
-            null
-          } else {
-            // TODO: I don't understand yet why ... Not sure it's because this PR
-            var data = item
-            if (item.isInstanceOf[Seq[Any]]) 
-              data = item.asInstanceOf[Seq[Any]](0)
-            println(s"SEB, item: $data")
+            println(s"SEB, item: $item")
             val record = new Record(schema)
             val convertersIterator = fieldConverters.iterator
             val fieldNamesIterator = dataType.asInstanceOf[StructType].fieldNames.iterator
-            // val row = item.asInstanceOf[Row]
-            val rowIterator = data.asInstanceOf[Row].toSeq.iterator
+            val rowIterator = item.asInstanceOf[Row].toSeq.iterator
 
-            // Parse in the dataset order
+            // Parse in the dataset order, Record doesn't depend on the order, only the schema does
             while (convertersIterator.hasNext) {
               val converter = convertersIterator.next()
-              // val currentFieldName = fieldNamesIterator.next()
-              // record.put(currentFieldName, converter(row.get(structType.getFieldIndex(currentFieldName).get)))
               record.put(fieldNamesIterator.next(), converter(rowIterator.next()))
             }
             record

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
@@ -321,6 +321,7 @@ object SchemaConverters {
               val converter = convertersIterator.next()
               record.put(fieldname, converter(row.get(row.fieldIndex(fieldname))))
             }
+            record
           }
         }
     }

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
@@ -311,8 +311,8 @@ object SchemaConverters {
           } else {
             // TODO: I don't understand yet why ... Not sure it's because this PR
             var data = item
-            if (item.isInstanceOf[Seq]) 
-              data = item(0)
+            if (item.isInstanceOf[Seq[Any]]) 
+              data = item.asInstanceOf[Seq[Any]](0)
             println(s"SEB, item: $data")
             val record = new Record(schema)
             val convertersIterator = fieldConverters.iterator

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
@@ -315,7 +315,7 @@ object SchemaConverters {
             val fieldNamesIterator = structType.fieldNames.iterator
             val convertersIterator = fieldConverters.iterator
 
-            if (row.schema != null)  {
+            if (row.schema == null)  {
               // Seems to always work on Travis, but fails in my environment
               while (convertersIterator.hasNext) {
                 val converter = convertersIterator.next()

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
@@ -281,8 +281,8 @@ object SchemaConverters {
       case MapType(StringType, valueType, _) =>
         val valueConverter = createConverterToAvro(
           valueType,
-          avroType.getField(fieldname).schema().getValueType,
-          avroType.getField(fieldname).schema().getValueType.getName, 
+          avroType.getField(currentFieldName).schema().getValueType,
+          avroType.getField(currentFieldName).schema().getValueType.getName, 
           recordNamespace)
         (item: Any) => {
           if (item == null) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
@@ -258,7 +258,8 @@ object SchemaConverters {
       case TimestampType => (item: Any) =>
         if (item == null) null else item.asInstanceOf[Timestamp].getTime
       case ArrayType(elementType, _) =>
-        val elementConverter = createConverterToAvro(elementType,avroType.getField(structName).schema().getElementType, structName, recordNamespace)
+        val fieldname = dataType.asInstanceOf[StructType].fieldNames(0)
+        val elementConverter = createConverterToAvro(elementType,avroType.getField(fieldname).schema().getElementType, structName, recordNamespace)
         (item: Any) => {
           if (item == null) {
             null
@@ -275,7 +276,8 @@ object SchemaConverters {
           }
         }
       case MapType(StringType, valueType, _) =>
-        val valueConverter = createConverterToAvro(valueType,avroType.getField(structName).schema().getElementType, structName, recordNamespace)
+        val fieldname = dataType.asInstanceOf[StructType].fieldNames(0)
+        val valueConverter = createConverterToAvro(valueType,avroType.getField(fieldname).schema().getValueType, structName, recordNamespace)
         (item: Any) => {
           if (item == null) {
             null

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
@@ -306,6 +306,9 @@ object SchemaConverters {
             field.name,
             recordNamespace))
         (item: Any) => {
+          if (item == null) {
+            null
+          } else {
             println(s"SEB, item: $item")
             val record = new Record(schema)
             val convertersIterator = fieldConverters.iterator

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
@@ -312,14 +312,15 @@ object SchemaConverters {
             val record = new Record(schema)
             val convertersIterator = fieldConverters.iterator
             val fieldNamesIterator = dataType.asInstanceOf[StructType].fieldNames.iterator
-            val rowIterator = item.asInstanceOf[Row].toSeq.iterator
-
-            // Parse in the dataset order, Record doesn't depend on the order, only the schema does
-            while (convertersIterator.hasNext) {
+            val row = item.asInstanceOf[Row]
+            
+            // Resolve the column by name, don't use the iterator row.toSeq.iterator
+            // which doesn't deliver columns in the expected order
+            while (fieldNamesIterator.hasNext) {
+              val fieldname = fieldNamesIterator.next()
               val converter = convertersIterator.next()
-              record.put(fieldNamesIterator.next(), converter(rowIterator.next()))
+              record.put(fieldname, converter(row.get(row.fieldIndex(fieldname))))
             }
-            record
           }
         }
     }

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/types/Avro.scala
@@ -309,16 +309,19 @@ object SchemaConverters {
           if (item == null) {
             null
           } else {
+            println(s"SEB, item: $item")
             val record = new Record(schema)
             val convertersIterator = fieldConverters.iterator
             val fieldNamesIterator = dataType.asInstanceOf[StructType].fieldNames.iterator
-            val row = item.asInstanceOf[Row]
+            // val row = item.asInstanceOf[Row]
+            val rowIterator = item.asInstanceOf[Row].toSeq.iterator
 
             // Parse in the dataset order
             while (convertersIterator.hasNext) {
               val converter = convertersIterator.next()
-              val currentFieldName = fieldNamesIterator.next()
-              record.put(currentFieldName, converter(row.get(structType.getFieldIndex(currentFieldName).get)))
+              // val currentFieldName = fieldNamesIterator.next()
+              // record.put(currentFieldName, converter(row.get(structType.getFieldIndex(currentFieldName).get)))
+              record.put(fieldNamesIterator.next(), converter(rowIterator.next()))
             }
             record
           }

--- a/core/src/test/scala/org/apache/spark/sql/AvroRecordSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/AvroRecordSuite.scala
@@ -248,7 +248,7 @@ class AvroRecordSuite extends FunSuite with BeforeAndAfterEach with BeforeAndAft
     println(s"sqlRec1: $sqlRec1")
   }
 	
-test("avro to schema field order setup") {
+test("avro not dependent on schema field order") {
     val schemaString  =
       s"""{"namespace": "example.avro",
          |   "type": "record", "name": "User",
@@ -277,12 +277,12 @@ test("avro to schema field order setup") {
     user2.put("bool", false)
 
     val sqlUser1 = SchemaConverters.createConverterToSQL(avroDatasetSchema)(user1)
-    println(sqlUser1)
+    println(s"user1 from sql: $sqlUser1")
     val schema = SchemaConverters.toSqlType(avroDatasetSchema)
     println(s"\nSqlschema: $schema")
     val avroUser1 = SchemaConverters.createConverterToAvro(schema.dataType, avroSchema,"avro", "example.avro")(sqlUser1)
     val avroByte = AvroSerde.serialize(avroUser1, avroSchema)
     val avroUser11 = AvroSerde.deserialize(avroByte, avroSchema)
-    println(s"$avroUser1")
+    println(s"user1 deserialized: $avroUser1")
   }
 }

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/AvroRecord.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/AvroRecord.scala
@@ -47,7 +47,7 @@ object AvroRecord {
     println(sqlUser1)
     val schema = SchemaConverters.toSqlType(avroSchema)
     println(s"\nSqlschema: $schema")
-    val avroUser1 = SchemaConverters.createConverterToAvro(schema.dataType, "avro", "example.avro")(sqlUser1)
+    val avroUser1 = SchemaConverters.createConverterToAvro(schema.dataType, avroSchema, "avro", "example.avro")(sqlUser1)
     val avroByte = AvroSerde.serialize(avroUser1, avroSchema)
     val avroUser11 = AvroSerde.deserialize(avroByte, avroSchema)
     println(s"$avroUser1")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use the user supplied Avro schema to both serialize and deserialize, instead of using the generated Avro schema from the dataset as Avro schema are dependent on field order.
This avoid to users to have dataset fields in the same order than in their Avro schema.

## How was this patch tested?

Added unit test: "avro not dependent on schema field order"
