### PR TITLE
Patch field order with avro 

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
@@ -95,7 +95,7 @@ case class Field(
 
   // converter from catalyst to avro
   lazy val catalystToAvro: (Any) => Any ={
-    SchemaConverters.createConverterToAvro(dt, colName, "recordNamespace")
+    SchemaConverters.createConverterToAvro(dt, exeSchema.get,colName, "recordNamespace")
   }
 
   val dt =

--- a/core/src/test/scala/org/apache/spark/sql/AvroRecordSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/AvroRecordSuite.scala
@@ -54,7 +54,7 @@ class AvroRecordSuite extends FunSuite with BeforeAndAfterEach with BeforeAndAft
     println(sqlUser1)
     val schema = SchemaConverters.toSqlType(avroSchema)
     println(s"\nSqlschema: $schema")
-    val avroUser1 = SchemaConverters.createConverterToAvro(schema.dataType, "avro", "example.avro")(sqlUser1)
+    val avroUser1 = SchemaConverters.createConverterToAvro(schema.dataType, avroSchema,"avro", "example.avro")(sqlUser1)
     val avroByte = AvroSerde.serialize(avroUser1, avroSchema)
     val avroUser11 = AvroSerde.deserialize(avroByte, avroSchema)
     println(s"$avroUser1")
@@ -77,7 +77,7 @@ class AvroRecordSuite extends FunSuite with BeforeAndAfterEach with BeforeAndAft
     println(sqlConv)
     val sqlSchema = SchemaConverters.toSqlType(avroSchema)
     println(s"\nSqlschema: $sqlSchema")
-    val avroData = SchemaConverters.createConverterToAvro(sqlSchema.dataType, "avro", "example.avro")(sqlConv)
+    val avroData = SchemaConverters.createConverterToAvro(sqlSchema.dataType, avroSchema,"avro", "example.avro")(sqlConv)
     val avroBytes = AvroSerde.serialize(avroData, avroSchema)
     val desData = AvroSerde.deserialize(avroBytes, avroSchema)
     println(s"$desData")
@@ -107,7 +107,7 @@ class AvroRecordSuite extends FunSuite with BeforeAndAfterEach with BeforeAndAft
 	println(sqlConv)
 	val sqlSchema = SchemaConverters.toSqlType(avroSchema)
 	println(s"\nSqlschema: $sqlSchema")
-	val avroData = SchemaConverters.createConverterToAvro(sqlSchema.dataType, "avro", "example.avro")(sqlConv)
+	val avroData = SchemaConverters.createConverterToAvro(sqlSchema.dataType, avroSchema,"avro", "example.avro")(sqlConv)
 	val avroBytes = AvroSerde.serialize(avroData, avroSchema)
 	val desData = AvroSerde.deserialize(avroBytes, avroSchema)
 	println(s"$desData")
@@ -238,7 +238,7 @@ class AvroRecordSuite extends FunSuite with BeforeAndAfterEach with BeforeAndAft
     val sqlRec = SchemaConverters.createConverterToSQL(avroComplex)(avroRec)
     println(s"\nsqlRec: $sqlRec")
 
-    val avroRec1 = SchemaConverters.createConverterToAvro(schema.dataType, "test_schema", "example.avro")(sqlRec)
+    val avroRec1 = SchemaConverters.createConverterToAvro(schema.dataType, avroComplex,"test_schema", "example.avro")(sqlRec)
     println(s"\navroRec1: $avroRec1")
     val avroByte = AvroSerde.serialize(avroRec1, avroComplex)
     println("\nserialize")
@@ -246,5 +246,43 @@ class AvroRecordSuite extends FunSuite with BeforeAndAfterEach with BeforeAndAft
     println(s"\navroRec11: $avroRec11")
     val sqlRec1 = SchemaConverters.createConverterToSQL(avroComplex)(avroRec11)
     println(s"sqlRec1: $sqlRec1")
+  }
+	
+test("avro not dependent on schema field order") {
+    val schemaString  =
+      s"""{"namespace": "example.avro",
+         |   "type": "record", "name": "User",
+         |    "fields": [ {"name": "name", "type": "string"},
+         |      {"name": "bool",  "type": "boolean"} ] }""".stripMargin
+    val avroSchema: Schema = {
+      val p = new Schema.Parser
+      p.parse(schemaString)
+    }
+    val schemaDatasetString  =
+      s"""{"namespace": "example.avro",
+         |   "type": "record", "name": "User",
+         |    "fields": [ {"name": "bool", "type": "boolean"},
+         |      {"name": "name",  "type": "string"} ] }""".stripMargin
+    val avroDatasetSchema: Schema = {
+      val p = new Schema.Parser
+      p.parse(schemaDatasetString)
+    }
+
+    val user1 = new GenericData.Record(avroDatasetSchema)
+    user1.put("name", "Alyssa")
+    user1.put("bool", true)
+
+    val user2 = new GenericData.Record(avroDatasetSchema)
+    user2.put("name", "Ben")
+    user2.put("bool", false)
+
+    val sqlUser1 = SchemaConverters.createConverterToSQL(avroDatasetSchema)(user1)
+    println(s"user1 from sql: $sqlUser1")
+    val schema = SchemaConverters.toSqlType(avroDatasetSchema)
+    println(s"\nSqlschema: $schema")
+    val avroUser1 = SchemaConverters.createConverterToAvro(schema.dataType, avroSchema,"avro", "example.avro")(sqlUser1)
+    val avroByte = AvroSerde.serialize(avroUser1, avroSchema)
+    val avroUser11 = AvroSerde.deserialize(avroByte, avroSchema)
+    println(s"user1 deserialized: $avroUser1")
   }
 }

--- a/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/AvroRecord.scala
+++ b/examples/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/AvroRecord.scala
@@ -47,7 +47,7 @@ object AvroRecord {
     println(sqlUser1)
     val schema = SchemaConverters.toSqlType(avroSchema)
     println(s"\nSqlschema: $schema")
-    val avroUser1 = SchemaConverters.createConverterToAvro(schema.dataType, "avro", "example.avro")(sqlUser1)
+    val avroUser1 = SchemaConverters.createConverterToAvro(schema.dataType, avroSchema, "avro", "example.avro")(sqlUser1)
     val avroByte = AvroSerde.serialize(avroUser1, avroSchema)
     val avroUser11 = AvroSerde.deserialize(avroByte, avroSchema)
     println(s"$avroUser1")


### PR DESCRIPTION


## What changes were proposed in this pull request?

Fix toBytes() to be not dependent on fields order in the incoming dataset to serialize in Avro.
This fix should in the mean time have better performance as we don't need to generate the Avro Schema from the dataset for each row (we only use the user supplied one)

## How was this patch tested?

New Unit Test: "avro not dependent on schema field order"
This test as been submitted in https://github.com/hortonworks-spark/shc/pull/247 => it fails
With this patch => it succeeds
