### PR TITLE
Pushdown filters for  Boolean type when query from HBase

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/ScanRange.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/ScanRange.scala
@@ -412,7 +412,7 @@ object BoundRange extends Logging{
           Some(BoundRanges(Array(BoundRange(min, b)),Array(BoundRange(b, max)), b))
         }
 
-      case _: Array[Byte] | _: Byte | _: String | _: UTF8String =>
+      case _: Array[Byte] | _: Byte | _: String | _: UTF8String | _: Boolean =>
         Some(BoundRanges(
           Array(BoundRange(Array.fill(b.length)(ByteMin), b)),
           Array(BoundRange(b, Array.fill(b.length)(ByteMax))), b))

--- a/core/src/test/scala/org/apache/spark/sql/ScanRangeTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/ScanRangeTestSuite.scala
@@ -17,12 +17,11 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.sql.execution.datasources.hbase.Logging
+import org.apache.spark.sql.execution.datasources.hbase.{Bound, BoundRange, Field, Logging, ScanRange}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuite}
-
 import org.apache.hadoop.hbase.util.Bytes
 import org.apache.spark.sql.execution.datasources.hbase
-import org.apache.spark.sql.execution.datasources.hbase.{Bound, ScanRange}
+import org.apache.spark.sql.execution.datasources.hbase.types.SHCDataTypeFactory
 import org.apache.spark.sql.types.BinaryType
 
 class ScanRangeTestSuite  extends FunSuite with BeforeAndAfterEach with BeforeAndAfterAll  with Logging {
@@ -486,5 +485,14 @@ class ScanRangeTestSuite  extends FunSuite with BeforeAndAfterEach with BeforeAn
         Some(Bound[Array[Byte]](Array.fill(6)(-1: Byte), true))))
 
     assert(v.size == ret.size && v.toSet == ret)
+  }
+
+  test("Test BoundRange") {
+    val f = Field("col1", "f", "col1", "PrimitiveType", Some("boolean"), None, -1)
+    val coder = SHCDataTypeFactory.create(f)
+    val bBoolean = BoundRange(true.asInstanceOf[Any], f)
+
+    display
+    assert(!bBoolean.isEmpty && coder.fromBytes(bBoolean.get.value).asInstanceOf[Boolean])
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

shc tries to build filters translated by DataSourceStrategy, But it can't produce a BoundRanges for a filter of type Boolean.

## How was this patch tested?
Unit Test: "Test BoundRange"
