### PR TITLE
Added Region caching

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -126,6 +126,11 @@
       <version>${avro.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.github.blemale</groupId>
+      <artifactId>scaffeine_2.11</artifactId>
+      <version>2.5.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
       <version>2.2.1</version>

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -76,9 +76,6 @@ private[hbase] class HBaseTableScanRDD(
   private def sparkConf = SparkEnv.get.conf
   val serializedToken = relation.serializedToken
 
-  val useCache = sparkConf.getBoolean(SparkHBaseConf.MetaCacheEnabled, SparkHBaseConf.defaultMetaCacheEnabled)
-  var regionHook : HBaseRelation => RegionResource = if (useCache) relation => MetaCache.get(relation) else relation => RegionResource(relation)
-
   override def getPartitions: Array[Partition] = {
     val hbaseFilter = HBaseFilter.buildFilters(filters, relation)
     var idx = 0

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -35,9 +35,8 @@ import org.apache.spark.sql.execution.datasources.hbase.types.{SHCDataType, SHCD
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types._
 import org.apache.spark.util.ShutdownHookManager
-import com.github.blemale.scaffeine.{ LoadingCache, Scaffeine }
+import com.github.blemale.scaffeine.{LoadingCache, Scaffeine}
 import scala.concurrent.duration._
-
 import scala.collection.mutable
 import scala.util.matching.Regex
 
@@ -55,8 +54,9 @@ private[hbase] case class HBaseScanPartition(
 
 object MetaCache {
   private def sparkConf = SparkEnv.get.conf
+  private[this] val expirySeconds = sparkConf.getTimeAsSeconds(SparkHBaseConf.MetaCacheDuration, SparkHBaseConf.defaultMetaCacheDuration)
   private[this] val cache: LoadingCache[HBaseRelation, RegionResource] = Scaffeine()
-    .expireAfterWrite(5.minutes)
+    .expireAfterWrite(Duration(expirySeconds, SECONDS))
     .build((relation: HBaseRelation) => RegionResource(relation))
 
   def get(relation: HBaseRelation) : RegionResource = this.cache.get(relation)
@@ -71,10 +71,13 @@ private[hbase] class HBaseTableScanRDD(
   private def sparkConf = SparkEnv.get.conf
   val serializedToken = relation.serializedToken
 
+  val useCache = sparkConf.getBoolean(SparkHBaseConf.MetaCacheEnabled, SparkHBaseConf.defaultMetaCacheEnabled)
+  var regionHook : HBaseRelation => RegionResource = if (useCache) relation => MetaCache.get(relation) else relation => RegionResource(relation)
+
   override def getPartitions: Array[Partition] = {
     val hbaseFilter = HBaseFilter.buildFilters(filters, relation)
     var idx = 0
-    val r = MetaCache.get(relation)
+    val r = regionHook(relation)
     logDebug(s"There are ${r.size} regions")
     val ps = r.flatMap { x=>
       // HBase take maximum as empty byte array, change it here.

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -35,6 +35,8 @@ import org.apache.spark.sql.execution.datasources.hbase.types.{SHCDataType, SHCD
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types._
 import org.apache.spark.util.ShutdownHookManager
+import com.github.blemale.scaffeine.{ LoadingCache, Scaffeine }
+import scala.concurrent.duration._
 
 import scala.collection.mutable
 import scala.util.matching.Regex
@@ -51,6 +53,15 @@ private[hbase] case class HBaseScanPartition(
     scanRanges: Array[ScanRange[Array[Byte]]],
     tf: SerializedTypedFilter) extends Partition
 
+object MetaCache {
+  private def sparkConf = SparkEnv.get.conf
+  private[this] val cache: LoadingCache[HBaseRelation, RegionResource] = Scaffeine()
+    .expireAfterWrite(5.minutes)
+    .build((relation: HBaseRelation) => RegionResource(relation))
+
+  def get(relation: HBaseRelation) : RegionResource = this.cache.get(relation)
+}
+
 private[hbase] class HBaseTableScanRDD(
     relation: HBaseRelation,
     requiredColumns: Array[String],
@@ -63,7 +74,7 @@ private[hbase] class HBaseTableScanRDD(
   override def getPartitions: Array[Partition] = {
     val hbaseFilter = HBaseFilter.buildFilters(filters, relation)
     var idx = 0
-    val r = RegionResource(relation)
+    val r = MetaCache.get(relation)
     logDebug(s"There are ${r.size} regions")
     val ps = r.flatMap { x=>
       // HBase take maximum as empty byte array, change it here.

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/SparkHBaseConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/SparkHBaseConf.scala
@@ -22,6 +22,7 @@ package org.apache.spark.sql.execution.datasources.hbase
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.execution.datasources.hbase.types._
+import scala.concurrent.duration._
 
 
 object SparkHBaseConf {
@@ -38,6 +39,12 @@ object SparkHBaseConf {
   var defaultBulkGetSize = 100
   var CachingSize = "spark.hbase.connector.cacheSize"
   var defaultCachingSize = 100
+
+  var MetaCacheEnabled = "spark.hbase.connector.meta.cache.enabled"
+  var defaultMetaCacheEnabled = false
+  var MetaCacheDuration = "spark.hbase.connector.meta.cache.expiry"
+  var defaultMetaCacheDuration = "5min"
+
   // in milliseconds
   val connectionCloseDelay = 10 * 60 * 1000
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

My team and I have been testing the shc connector with high and very high throughput and we realized that its performance dropped significantly around 400 k reads per second and, prior to these changes, we could never go above 500 k reads per second in a stable manner. 

We managed to pinpoint and patch the problem. It was related to repeated region queries that saturated the cluster.

We have exposed our changes via parameters, which are disabled by default.

## How was this patch tested?

This patch was tested manually. It has also been used extensively in our tests in the CERN's NxCals project for the past 3 weeks. We have deemed it stable and efficient enough to move it to our production environment.
