### PR TITLE
Added enhancement / support for Google BigTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Given a DataFrame with specified schema, above will create an HBase table with 5
       .format("org.apache.spark.sql.execution.datasources.hbase")
       .save()
 
-For Google BigTable, given a DataFrame with specified schema, above will create an HBase table with 5 regions and save the DataFrame inside. Note that if HBaseTableCatalog.newTable is not specified, the table has to be pre-created.
+For Google BigTable, given a DataFrame with specified schema, above will create an Google BigTable with 5 regions and save the DataFrame inside. Note that if HBaseTableCatalog.newTable is not specified, the table has to be pre-created.
 Also HBaseTableCatalog.tablePlatform -> "bigtable" must be specified explicitly for Google BigTable. If not specified By default this assumes table type as hbase.
 
 

--- a/README.md
+++ b/README.md
@@ -85,10 +85,21 @@ The above defines a schema for a HBase table with name as table1, row key as key
       Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5"))
       .format("org.apache.spark.sql.execution.datasources.hbase")
       .save()
-      
+
 Given a DataFrame with specified schema, above will create an HBase table with 5 regions and save the DataFrame inside. Note that if HBaseTableCatalog.newTable is not specified, the table has to be pre-created.
 
-### Perform DataFrame operation on top of HBase table
+### Write to Google BigTable to populate data
+
+    sc.parallelize(data).toDF.write.options(
+      Map(HBaseTableCatalog.tablePlatform -> "bigtable", HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5"))
+      .format("org.apache.spark.sql.execution.datasources.hbase")
+      .save()
+
+For Google BigTable, given a DataFrame with specified schema, above will create an HBase table with 5 regions and save the DataFrame inside. Note that if HBaseTableCatalog.newTable is not specified, the table has to be pre-created.
+Also HBaseTableCatalog.tablePlatform -> "bigtable" must be specified explicitly for Google BigTable. If not specified By default this assumes table type as hbase.
+
+
+### Perform DataFrame operation on top of HBase and Google BigTable
 
     def withCatalog(cat: String): DataFrame = {
       sqlContext

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The above defines a schema for a HBase table with name as table1, row key as key
 ### Write to HBase table to populate data
 
     sc.parallelize(data).toDF.write.options(
-      Map(HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5"))
+      Map(HBaseTableCatalog.tablePlatform -> "hbase", HBaseTableCatalog.tableCatalog -> catalog, HBaseTableCatalog.newTable -> "5"))
       .format("org.apache.spark.sql.execution.datasources.hbase")
       .save()
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
@@ -169,6 +169,10 @@ case class HBaseTableCatalog(
     coderSet: Set[String],
     val numReg: Int,
     val splitRange: (String, String)) extends Logging {
+  // Table type can also be Google Big Table
+  var tablePlatform: String = "bigtable"
+  def setTablePlatform(tableplatform: String) = this.tablePlatform = tableplatform
+  def getTablePlatform: String = this.tablePlatform
   def toDataType = StructType(sMap.toFields)
   def getField(name: String) = sMap.getField(name)
   def getRowKey: Seq[Field] = row.fields
@@ -234,6 +238,8 @@ object HBaseTableCatalog {
   val rowKey = "rowkey"
   // The key for hbase table whose value specify namespace and table name
   val table = "table"
+  // type of table Hbase or BigTable
+  var tablePlatform = "tableplatform"
   // The namespace of hbase table
   val nameSpace = "namespace"
   // The name of hbase table
@@ -301,7 +307,11 @@ object HBaseTableCatalog {
     val minSplit = parameters.get(minTableSplitPoint).getOrElse("aaaaaa")
     val maxSplit = parameters.get(maxTableSplitPoint).getOrElse("zzzzzz")
 
-    HBaseTableCatalog(nSpace, tName, rKey, SchemaMap(schemaMap), tCoder, coderSet, numReg, (minSplit, maxSplit))
+    // HBaseTableCatalog(nSpace, tName, rKey, SchemaMap(schemaMap), tCoder, coderSet, numReg, (minSplit, maxSplit))
+    val hbasetablecatalogobject = HBaseTableCatalog(nSpace, tName, rKey, SchemaMap(schemaMap), tCoder, coderSet, numReg, (minSplit, maxSplit))
+    tablePlatform = tableMeta.get(tablePlatform).getOrElse("hbase").asInstanceOf[String]
+    hbasetablecatalogobject.setTablePlatform(tableplatform = tablePlatform)
+    hbasetablecatalogobject
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Basically HBase has Namespaces and Google Big Table do not.
Therefore while using this API for writing data into Google BigTable the class must not call methods of Namespaces viz. getNamespaceDescriptor, createNamespaces etc. [Check this](https://cloud.google.com/bigtable/docs/hbase-differences)

Made adjustments in HBaseRelation.scala & HBaseTableCatalog.scala. I had to create an if else branch for that based on "tabletype" argument passed to HBaseTableCatalog class. "tabletype" variable takes value "bigtable" by default if not explicitly specified. Use "hbase" when using this API for HBase.

README.md is updated as well to illustrate the usage.

## How was this patch tested?
This patch was tested manually. It has also been used extensively in my project & running in production for the past 8 months.
I think now it is stable and now is the good time to create pull request & merge into master.

An Example of using this with Google BigTable is [here](https://github.com/vim89/gcp-datalake)

Regards,
Vitthal